### PR TITLE
Add New Project Modal for project creation

### DIFF
--- a/CalendarMaker-MAUI/CalendarMaker-MAUI.csproj
+++ b/CalendarMaker-MAUI/CalendarMaker-MAUI.csproj
@@ -75,6 +75,12 @@
 	  <MauiXaml Update="Views\PhotoSelectorModal.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\NewProjectModal.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Views\CalendarModal.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	</ItemGroup>
 
 </Project>

--- a/CalendarMaker-MAUI/Views/NewProjectModal.xaml
+++ b/CalendarMaker-MAUI/Views/NewProjectModal.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="CalendarMaker_MAUI.Views.NewProjectModal"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="New Project">
+    <VerticalStackLayout Padding="20" Spacing="16">
+        <Label Text="Create New Project" FontAttributes="Bold" FontSize="20" />
+
+        <VerticalStackLayout Spacing="8">
+            <Label Text="Preset" />
+            <Picker x:Name="PresetPicker">
+                <Picker.Items>
+                    <x:String>5x7 Landscape</x:String>
+                    <x:String>Letter Portrait</x:String>
+                </Picker.Items>
+            </Picker>
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="8">
+            <Label Text="Project Name" />
+            <Entry x:Name="NameEntry" Placeholder="My Calendar" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="8">
+            <Label Text="Calendar Year" />
+            <Entry x:Name="YearEntry" Keyboard="Numeric" />
+        </VerticalStackLayout>
+
+        <HorizontalStackLayout Spacing="12" HorizontalOptions="End">
+            <Button x:Name="CancelBtn" Text="Cancel" />
+            <Button x:Name="CreateBtn" Text="Create" />
+        </HorizontalStackLayout>
+    </VerticalStackLayout>
+</ContentPage>

--- a/CalendarMaker-MAUI/Views/NewProjectModal.xaml.cs
+++ b/CalendarMaker-MAUI/Views/NewProjectModal.xaml.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+
+namespace CalendarMaker_MAUI.Views;
+
+public partial class NewProjectModal : ContentPage
+{
+    public string? SelectedPreset { get; private set; }
+    public string? ProjectName { get; private set; }
+    public int? Year { get; private set; }
+
+    public event EventHandler? Cancelled;
+    public event EventHandler? Created;
+
+    public NewProjectModal()
+    {
+        InitializeComponent();
+
+        // Defaults
+        PresetPicker.SelectedIndex = 0;
+        YearEntry.Text = DateTime.Now.Year.ToString();
+        NameEntry.Text = "My Calendar";
+
+        CancelBtn.Clicked += (_, __) => { Cancelled?.Invoke(this, EventArgs.Empty); };
+        CreateBtn.Clicked += OnCreateClicked;
+    }
+
+    private void OnCreateClicked(object? sender, EventArgs e)
+    {
+        SelectedPreset = PresetPicker.SelectedIndex switch
+        {
+            0 => "5x7 Landscape 50/50 (Photo Left)",
+            1 => "Letter Portrait 50/50 (Photo Top)",
+            _ => "5x7 Landscape 50/50 (Photo Left)"
+        };
+
+        var name = NameEntry.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(name)) name = "My Calendar";
+        ProjectName = name;
+
+        if (int.TryParse(YearEntry.Text, out var year))
+        {
+            Year = year;
+        }
+        else
+        {
+            Year = DateTime.Now.Year;
+        }
+
+        Created?.Invoke(this, EventArgs.Empty);
+    }
+}


### PR DESCRIPTION
closes #4 

Introduced a new `NewProjectModal` to enhance the user experience for creating projects. The modal provides a structured interface with fields for preset selection, project name, and calendar year, replacing the previous sequential prompts.

Updated `ProjectsPage` to use the new modal, leveraging its `Cancelled` and `Created` events for handling user input. Refactored project creation logic to improve modularity and maintainability.

Registered `NewProjectModal.xaml` in `CalendarMaker-MAUI.csproj` to ensure it is compiled and included in the application.