### PR TITLE
Update NuGet dependencies and refine test project config

### DIFF
--- a/CalendarMaker-MAUI/CalendarMaker-MAUI.csproj
+++ b/CalendarMaker-MAUI/CalendarMaker-MAUI.csproj
@@ -56,12 +56,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0-rc.1.25451.107" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="12.2.0" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
-		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.6" />
-		<PackageReference Include="QuestPDF" Version="2024.6.1" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="12.3.0" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.1" />
+		<PackageReference Include="QuestPDF" Version="2025.7.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/CalendarMaker.Tests/CalendarMaker.Tests.csproj
+++ b/CalendarMaker.Tests/CalendarMaker.Tests.csproj
@@ -13,12 +13,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -27,6 +33,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../CalendarMaker-MAUI/CalendarMaker-MAUI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.Maui.Controls" Version="10.0.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgraded several NuGet package dependencies in `CalendarMaker-MAUI.csproj`:
- `Microsoft.Maui.Controls` to `10.0.10`
- `Microsoft.Extensions.Logging.Debug` to `10.0.0`
- `CommunityToolkit.Maui` to `12.3.0`
- `CommunityToolkit.Mvvm` to `8.4.0`
- `SkiaSharp.Views.Maui.Controls` to `3.119.1`
- `QuestPDF` to `2025.7.4`

Updated test-related dependencies in `CalendarMaker.Tests.csproj`:
- `coverlet.collector` to `6.0.4` with metadata adjustments
- `Microsoft.NET.Test.Sdk` to `18.0.1`
- `xunit` to `2.9.3`
- `xunit.runner.visualstudio` to `3.1.5` with metadata adjustments

Added an `ItemGroup` in `CalendarMaker.Tests.csproj` to update `Microsoft.Maui.Controls` to `10.0.10`.

Improved dependency management by adding `PrivateAssets` and `IncludeAssets` metadata where applicable. These changes enhance functionality, compatibility, and maintainability.