### PR TITLE
Enhance photo picker modal

### DIFF
--- a/CalendarMaker-MAUI/Models/ImageAsset.cs
+++ b/CalendarMaker-MAUI/Models/ImageAsset.cs
@@ -21,6 +21,11 @@ public sealed class ImageAsset
     public string Path { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the original file name when the image was imported.
+    /// </summary>
+    public string? OriginalFileName { get; set; }
+
+    /// <summary>
     /// Gets or sets the role of the image in the calendar. Valid values are "monthPhoto" or "coverPhoto".
     /// </summary>
     public string Role { get; set; } = "monthPhoto";

--- a/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
+++ b/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
@@ -382,16 +382,63 @@ public sealed partial class DesignerViewModel : ObservableObject
          await _navigationService.PopModalAsync();
      };
 
-        modal.RemoveRequested += async (_, __) =>
-           {
-               if (Project == null)
-               {
-                   return;
-               }
+        modal.UnassignRequested += async (_, __) =>
+        {
+            if (Project == null)
+            {
+                return;
+            }
 
-               await RemovePhotoFromActiveSlotAsync();
-               await _navigationService.PopModalAsync();
-           };
+            await UnassignPhotoFromActiveSlotAsync();
+            SyncZoomUI();
+            OnPropertyChanged(nameof(Project)); // Trigger canvas refresh
+            await _navigationService.PopModalAsync();
+        };
+
+        modal.DeleteRequested += async (_, args) =>
+        {
+            if (Project == null)
+            {
+                return;
+            }
+
+            // Determine which photo to delete
+            string? photoPath = null;
+
+            if (args.SelectedAsset != null)
+            {
+                // Delete the selected photo from the modal
+                photoPath = args.SelectedAsset.Path;
+            }
+            else
+            {
+                // Delete the photo in the active slot
+                var activeAsset = GetActiveAsset();
+                if (activeAsset != null)
+                {
+                    photoPath = activeAsset.Path;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(photoPath))
+            {
+                // Confirm deletion
+                bool confirm = await _dialogService.ShowConfirmAsync(
+                    "Delete Photo",
+                    "This will permanently delete the photo file and remove it from all pages. Continue?",
+                    "Delete",
+                    "Cancel");
+
+                if (confirm)
+                {
+                    await _assets.DeletePhotoFromProjectAsync(Project, photoPath);
+                    SyncZoomUI();
+                    OnPropertyChanged(nameof(Project)); // Trigger canvas refresh
+                }
+            }
+
+            await _navigationService.PopModalAsync();
+        };
 
         modal.Cancelled += async (_, __) =>
         {
@@ -795,7 +842,7 @@ public sealed partial class DesignerViewModel : ObservableObject
         }
     }
 
-    private async Task RemovePhotoFromActiveSlotAsync()
+    private async Task UnassignPhotoFromActiveSlotAsync()
     {
         if (Project == null)
         {
@@ -822,7 +869,7 @@ public sealed partial class DesignerViewModel : ObservableObject
                 await _storage.UpdateProjectAsync(Project);
             }
         }
-        else
+        else // Month pages (including -2 for previous December)
         {
             await _assets.RemovePhotoFromSlotAsync(Project, PageIndex, ActiveSlotIndex, "monthPhoto");
         }

--- a/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
+++ b/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
@@ -162,7 +162,7 @@ public sealed partial class DesignerViewModel : ObservableObject
         _filePickerService = filePickerService;
 
         // Initialize commands
-        NavigatePageCommand = new RelayCommand<int>(NavigatePage);
+        NavigatePageCommand = new RelayCommand<object>(NavigatePage);
         ImportPhotosCommand = new AsyncRelayCommand(ImportPhotosAsync);
         ShowPhotoSelectorCommand = new AsyncRelayCommand(ShowPhotoSelectorAsync);
         ShowProjectSettingsCommand = new AsyncRelayCommand(ShowProjectSettingsAsync);
@@ -280,8 +280,20 @@ public sealed partial class DesignerViewModel : ObservableObject
 
     #region Command Implementations
 
-    private void NavigatePage(int direction)
+    private void NavigatePage(object? parameter)
     {
+        int direction = parameter switch
+        {
+            int i => i,
+            string s when int.TryParse(s, out int parsed) => parsed,
+            _ => 0
+        };
+
+        if (direction == 0)
+        {
+            return;
+        }
+
         PageIndex += direction;
 
         // Determine page range based on double-sided mode

--- a/CalendarMaker-MAUI/Views/DesignerPage.xaml
+++ b/CalendarMaker-MAUI/Views/DesignerPage.xaml
@@ -11,7 +11,7 @@
                 <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="6">
                     <Button Text="Prev" 
                             Command="{Binding NavigatePageCommand}" 
-                            CommandParameter="{x:Int32 -1}"
+                            CommandParameter="-1"
                             Grid.Column="0" />
                     <Label Text="{Binding PageLabel}" 
                            Grid.Column="1" 
@@ -19,7 +19,7 @@
                            HorizontalTextAlignment="Center" />
                     <Button Text="Next" 
                             Command="{Binding NavigatePageCommand}" 
-                            CommandParameter="{x:Int32 1}"
+                            CommandParameter="1"
                             Grid.Column="2" />
                     <!-- Settings Cog Icon -->
                     <Border Grid.Column="3"

--- a/CalendarMaker-MAUI/Views/DesignerPage.xaml.cs
+++ b/CalendarMaker-MAUI/Views/DesignerPage.xaml.cs
@@ -442,8 +442,14 @@ public partial class DesignerPage : ContentPage
             if ((now - _viewModel.LastTapAt).TotalMilliseconds < 300 &&
                 SKPoint.Distance(pagePt, _viewModel.LastTapPoint) < 10)
             {
-                // Execute command using Task.Run to avoid async warning
-                _ = Task.Run(async () => await ((AsyncRelayCommand)_viewModel.ShowPhotoSelectorCommand).ExecuteAsync(null));
+                // Execute command on UI thread
+                MainThread.BeginInvokeOnMainThread(async () =>
+                {
+                    if (_viewModel.ShowPhotoSelectorCommand is IAsyncRelayCommand command)
+                    {
+                        await command.ExecuteAsync(null);
+                    }
+                });
             }
 
             _viewModel.LastTapAt = now;

--- a/CalendarMaker-MAUI/Views/PhotoSelectorModal.xaml
+++ b/CalendarMaker-MAUI/Views/PhotoSelectorModal.xaml
@@ -18,6 +18,7 @@
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
                 <Button x:Name="CancelBtn" 
@@ -36,9 +37,18 @@
                        HorizontalOptions="Center"
                        VerticalOptions="Center" />
 
-                <Button x:Name="RemoveBtn" 
+                <Button x:Name="UnassignBtn" 
                         Grid.Column="2"
-                        Text="Remove"
+                        Text="Unassign"
+                        BackgroundColor="#FF8800"
+                        TextColor="White"
+                        FontSize="16"
+                        CornerRadius="8"
+                        Margin="0,0,8,0" />
+
+                <Button x:Name="DeleteBtn" 
+                        Grid.Column="3"
+                        Text="Delete Photo"
                         BackgroundColor="#FF4444"
                         TextColor="White"
                         FontSize="16"


### PR DESCRIPTION
This pull request introduces enhancements to the photo management workflow in the calendar maker application. The main improvements include support for tracking the original filename of imported images, the ability to permanently delete photos from a project (including file deletion), and refinements to the photo selection modal and navigation commands. These changes improve usability and make photo management more intuitive for users.

**Photo asset management improvements:**

* Added an `OriginalFileName` property to the `ImageAsset` model to store the original filename when importing images, and updated import and assignment logic to preserve this information. This filename is now displayed in the photo selector modal when available. [[1]](diffhunk://#diff-c11c0570734689ad30572e3b32aa564b3f1072618c62d805b638090bba2bb170R23-R27) [[2]](diffhunk://#diff-680de966c98750d91b8b20f26e7625438a8f10f69d24734b7bd642bafe617c66R53) [[3]](diffhunk://#diff-680de966c98750d91b8b20f26e7625438a8f10f69d24734b7bd642bafe617c66R97) [[4]](diffhunk://#diff-eeae59aa5ddb0f49bea758063c74813604fdf7abfc6600d69dba5a3c3843f70fR57-R66)
* Implemented a new `DeletePhotoFromProjectAsync` method in `IAssetService` and its implementation, allowing users to permanently delete a photo from the project and remove the physical file. [[1]](diffhunk://#diff-680de966c98750d91b8b20f26e7625438a8f10f69d24734b7bd642bafe617c66R11) [[2]](diffhunk://#diff-680de966c98750d91b8b20f26e7625438a8f10f69d24734b7bd642bafe617c66R144-R176)

**Photo selector modal enhancements:**

* Added "Unassign" and "Delete Photo" buttons to the photo selector modal, with corresponding events and handlers (`UnassignRequested` and `DeleteRequested`). The delete action prompts for confirmation and removes the photo from all slots and storage if confirmed. [[1]](diffhunk://#diff-39998df0aa376822717c74291ee2a872f4e13d02da267604bf936eb1e545318fR21) [[2]](diffhunk://#diff-39998df0aa376822717c74291ee2a872f4e13d02da267604bf936eb1e545318fL39-R51) [[3]](diffhunk://#diff-eeae59aa5ddb0f49bea758063c74813604fdf7abfc6600d69dba5a3c3843f70fL13-R14) [[4]](diffhunk://#diff-eeae59aa5ddb0f49bea758063c74813604fdf7abfc6600d69dba5a3c3843f70fL30-R32) [[5]](diffhunk://#diff-eeae59aa5ddb0f49bea758063c74813604fdf7abfc6600d69dba5a3c3843f70fL122-R143) [[6]](diffhunk://#diff-eeae59aa5ddb0f49bea758063c74813604fdf7abfc6600d69dba5a3c3843f70fR192-R201) [[7]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170L373-R439)

**Navigation and command handling:**

* Updated the `NavigatePageCommand` to accept a generic object parameter, allowing for more flexible command parameter passing from XAML. Adjusted the navigation logic to handle both integer and string inputs. [[1]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170L165-R165) [[2]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170L283-R296) [[3]](diffhunk://#diff-14304a7e737a750e4824d810d427bd464170ee328b999e3eb29d2d1cdb874c83L14-R22)
* Improved the double-tap photo selector invocation to ensure it runs on the UI thread for better stability.

**Photo slot management:**

* Renamed and refactored the method for removing a photo from the active slot to `UnassignPhotoFromActiveSlotAsync`, clarifying its purpose and ensuring consistent usage with the new modal events. [[1]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170L786-R845) [[2]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170L813-R872)