### PR TITLE
Bug Fixes

### DIFF
--- a/CalendarMaker-MAUI/Services/ILayoutCalculator.cs
+++ b/CalendarMaker-MAUI/Services/ILayoutCalculator.cs
@@ -19,10 +19,12 @@ public interface ILayoutCalculator
     List<SKRect> ComputePhotoSlots(SKRect area, PhotoLayout layout);
 
     /// <summary>
-    /// Computes the split between photo and calendar sections based on layout specifications.
+    /// Computes the split between photo and calendar sections based on layout specifications and page orientation.
+    /// Automatically adjusts placement for landscape vs portrait orientations.
     /// </summary>
     /// <param name="area">The total area to split.</param>
     /// <param name="spec">The layout specification containing placement and split ratio.</param>
+    /// <param name="pageSpec">The page specification containing orientation information.</param>
     /// <returns>A tuple containing the photo rectangle and calendar rectangle.</returns>
-    (SKRect photoRect, SKRect calendarRect) ComputeSplit(SKRect area, LayoutSpec spec);
+    (SKRect photoRect, SKRect calendarRect) ComputeSplit(SKRect area, LayoutSpec spec, PageSpec pageSpec);
 }

--- a/CalendarMaker-MAUI/Services/LayoutCalculator.cs
+++ b/CalendarMaker-MAUI/Services/LayoutCalculator.cs
@@ -27,11 +27,38 @@ public sealed class LayoutCalculator : ILayoutCalculator
     }
 
     /// <inheritdoc />
-    public (SKRect photoRect, SKRect calendarRect) ComputeSplit(SKRect area, LayoutSpec spec)
+    public (SKRect photoRect, SKRect calendarRect) ComputeSplit(SKRect area, LayoutSpec spec, PageSpec pageSpec)
     {
         float ratio = (float)Math.Clamp(spec.SplitRatio, 0.1, 0.9);
 
-        return spec.Placement switch
+        // Determine the effective placement based on orientation
+        LayoutPlacement effectivePlacement = spec.Placement;
+
+        // Auto-adjust placement based on orientation
+        if (pageSpec.Orientation == PageOrientation.Landscape)
+        {
+            // In landscape, convert vertical placements to horizontal
+            effectivePlacement = spec.Placement switch
+            {
+                LayoutPlacement.PhotoTopCalendarBottom => LayoutPlacement.PhotoLeftCalendarRight,
+                LayoutPlacement.PhotoBottomCalendarTop => LayoutPlacement.PhotoRightCalendarLeft,
+                // Keep horizontal placements as-is
+                _ => spec.Placement
+            };
+        }
+        else // Portrait
+        {
+            // In portrait, convert horizontal placements to vertical
+            effectivePlacement = spec.Placement switch
+            {
+                LayoutPlacement.PhotoLeftCalendarRight => LayoutPlacement.PhotoTopCalendarBottom,
+                LayoutPlacement.PhotoRightCalendarLeft => LayoutPlacement.PhotoBottomCalendarTop,
+                // Keep vertical placements as-is
+                _ => spec.Placement
+            };
+        }
+
+        return effectivePlacement switch
         {
             LayoutPlacement.PhotoLeftCalendarRight => (
              new SKRect(area.Left, area.Top, area.Left + area.Width * ratio, area.Bottom),

--- a/CalendarMaker-MAUI/Services/RenderAndExport.cs
+++ b/CalendarMaker-MAUI/Services/RenderAndExport.cs
@@ -301,7 +301,7 @@ public sealed class PdfExportService : IPdfExportService
         else
         {
             // Regular page: photo on one side, calendar on the other
-            (SKRect photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec);
+            (SKRect photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec, project.PageSpec);
 
             // Get photo layout for the photo month
             var photoLayout = project.MonthPhotoLayouts.TryGetValue(pageSpec.PhotoMonthIndex, out var perMonth)
@@ -586,7 +586,7 @@ public sealed class PdfExportService : IPdfExportService
         }
         else
         {
-            (SKRect photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec);
+            (SKRect photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec, project.PageSpec);
             var layout = project.MonthPhotoLayouts.TryGetValue(monthIndex, out var perMonth)
                 ? perMonth
                 : project.LayoutSpec.PhotoLayout;

--- a/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
+++ b/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
@@ -468,6 +468,12 @@ public sealed partial class DesignerViewModel : ObservableObject
 
         modal.Applied += async (_, __) =>
         {
+            if (Project != null)
+            {
+                // Update the timestamp to ensure changes are tracked
+                Project.UpdatedUtc = DateTime.UtcNow;
+            }
+
             // Save the updated project
             await _storage.UpdateProjectAsync(Project);
             await _navigationService.PopModalAsync();

--- a/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
+++ b/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
@@ -262,15 +262,23 @@ public sealed partial class DesignerViewModel : ObservableObject
         {
             return Project.FrontCoverPhotoLayout;
         }
+        else if (PageIndex == -2) // Previous December
+        {
+            // Calculate the December index the same way rendering does
+            int decemberIndex = Project.StartMonth == 1 ? 11 : 12 - Project.StartMonth;
+            return Project.MonthPhotoLayouts.TryGetValue(decemberIndex, out var layout)
+                ? layout
+                : Project.LayoutSpec.PhotoLayout;
+        }
         else if (PageIndex == 12)
         {
             return Project.BackCoverPhotoLayout;
         }
-        else if (PageIndex >= -2 && PageIndex <= 11)
+        else if (PageIndex >= 0 && PageIndex <= 11) // Regular month pages
         {
             return Project.MonthPhotoLayouts.TryGetValue(PageIndex, out var layout)
-                        ? layout
-                 : Project.LayoutSpec.PhotoLayout;
+                ? layout
+                : Project.LayoutSpec.PhotoLayout;
         }
 
         return PhotoLayout.Single;
@@ -675,11 +683,17 @@ public sealed partial class DesignerViewModel : ObservableObject
         {
             Project.FrontCoverPhotoLayout = layout;
         }
+        else if (PageIndex == -2) // Previous December
+        {
+            // Calculate the December index the same way rendering does
+            int decemberIndex = Project.StartMonth == 1 ? 11 : 12 - Project.StartMonth;
+            Project.MonthPhotoLayouts[decemberIndex] = layout;
+        }
         else if (PageIndex == 12)
         {
             Project.BackCoverPhotoLayout = layout;
         }
-        else if (PageIndex >= -2 && PageIndex <= 11)
+        else if (PageIndex >= 0 && PageIndex <= 11) // Regular month pages
         {
             Project.MonthPhotoLayouts[PageIndex] = layout;
         }

--- a/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
+++ b/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
@@ -508,6 +508,9 @@ public sealed partial class DesignerViewModel : ObservableObject
         };
 
         _ = _storage.UpdateProjectAsync(Project);
+        
+        // Trigger canvas refresh to show the flipped layout
+        OnPropertyChanged(nameof(Project));
     }
 
     private async Task ExportCurrentPageAsync()

--- a/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
+++ b/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
@@ -378,7 +378,8 @@ public sealed partial class DesignerViewModel : ObservableObject
          }
 
          await _assets.AssignPhotoToSlotAsync(Project, selected.Id, monthIndex ?? 0, slotIndex, role);
-         SyncZoomUI();
+         SyncZoomUI(); // Sync zoom UI to reflect the new photo's zoom (which should be 1.0)
+         OnPropertyChanged(nameof(Project)); // Trigger canvas refresh to show the new photo
          await _navigationService.PopModalAsync();
      };
 
@@ -745,6 +746,13 @@ public sealed partial class DesignerViewModel : ObservableObject
         }
     }
 
+    partial void OnActiveSlotIndexChanged(int value)
+    {
+        // Sync the zoom UI when the active slot changes
+        // This ensures the zoom slider reflects the zoom level of the newly selected photo
+        SyncZoomUI();
+    }
+
     #endregion
 
     #region Private Helper Methods
@@ -810,6 +818,11 @@ public sealed partial class DesignerViewModel : ObservableObject
         if (asset != null)
         {
             ZoomValue = Math.Clamp(asset.Zoom, 0.5, 3.0);
+        }
+        else
+        {
+            // Reset to default zoom when no asset is present
+            ZoomValue = 1.0;
         }
     }
 

--- a/CalendarMaker-MAUI/Views/DesignerPage.xaml.cs
+++ b/CalendarMaker-MAUI/Views/DesignerPage.xaml.cs
@@ -227,7 +227,7 @@ public partial class DesignerPage : ContentPage
         }
         else if (pageIndex == -2) // Previous December
         {
-            (photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec);
+            (photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec, project.PageSpec);
 
             int decemberIndex = project.StartMonth == 1 ? 11 : 12 - project.StartMonth;
             PhotoLayout layout = project.MonthPhotoLayouts.TryGetValue(decemberIndex, out PhotoLayout perMonth)
@@ -268,7 +268,7 @@ public partial class DesignerPage : ContentPage
         }
         else // Month page
         {
-            (photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec);
+            (photoRect, SKRect calRect) = _layoutCalculator.ComputeSplit(contentRect, project.LayoutSpec, project.PageSpec);
 
             PhotoLayout layout = project.MonthPhotoLayouts.TryGetValue(pageIndex, out PhotoLayout perMonth)
                 ? perMonth


### PR DESCRIPTION
This pull request improves the handling of page orientation and layout updates in the calendar rendering and editing workflow. The main focus is on making the layout split between photo and calendar sections responsive to page orientation (landscape vs portrait), ensuring UI updates correctly reflect changes, and improving the handling of special pages like the "previous December" page. The most important changes are grouped below:

**Layout Calculation & Orientation Handling**

* The `ILayoutCalculator.ComputeSplit` method now takes a `PageSpec` parameter and automatically adjusts the placement of photo and calendar sections based on the page's orientation (landscape or portrait), converting between horizontal and vertical placements as needed. (`ILayoutCalculator.cs`, `LayoutCalculator.cs`, `RenderAndExport.cs`, `DesignerPage.xaml.cs`) [[1]](diffhunk://#diff-48adde32c8a7d56f4caa28ff71c8d5310d9314f334fedbd83188d180e8cd935cL22-R29) [[2]](diffhunk://#diff-9822cd6adefc7f2f0d3fa142ceaec703f27223df72b720cd24408884e37585b4L30-R61) [[3]](diffhunk://#diff-32ff8719c23dd9620c39685abbc62fbd76b407aba1f4155beb78e43f8eabd500L304-R304) [[4]](diffhunk://#diff-32ff8719c23dd9620c39685abbc62fbd76b407aba1f4155beb78e43f8eabd500L589-R589) [[5]](diffhunk://#diff-320fb555cbc00a0d0e6857331765d221b6c9da7ff0e19e7ae702f0edbee2847cL230-R230) [[6]](diffhunk://#diff-320fb555cbc00a0d0e6857331765d221b6c9da7ff0e19e7ae702f0edbee2847cL271-R271)

**Special Page Support (Previous December)**

* The logic for handling the "previous December" page (`PageIndex == -2`) is added and aligned across methods that get or set the photo layout, ensuring consistent rendering and editing for this special page. (`DesignerViewModel.cs`) [[1]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170R265-R277) [[2]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170R695-R705)

**UI Update & Refresh Triggers**

* UI is now more responsive to changes: property change notifications are triggered after photo selection and layout flipping to ensure the canvas and controls refresh appropriately. (`DesignerViewModel.cs`) [[1]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170L381-R390) [[2]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170R511-R513)
* The zoom UI is synchronized whenever the active slot changes or when a photo is assigned or removed, so the zoom slider always reflects the current photo's zoom level or resets to default if no photo is present. (`DesignerViewModel.cs`) [[1]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170R772-R778) [[2]](diffhunk://#diff-b72ceed570a33d096e1fdb20e1529bbefb6f1de7296e8b6a7ff720ecbb044170R845-R849)

**Project Metadata Update**

* The project's `UpdatedUtc` timestamp is now updated whenever project settings are changed, improving tracking of modifications. (`DesignerViewModel.cs`)