### PR TITLE
Add 12x12 square page size (#54)

### DIFF
--- a/CalendarMaker-MAUI/Models/CalendarProject.cs
+++ b/CalendarMaker-MAUI/Models/CalendarProject.cs
@@ -106,6 +106,7 @@ public sealed class CalendarProject
         PageSize.Letter => "Letter",
         PageSize.Tabloid_11x17 => "11x17",
         PageSize.SuperB_13x19 => "13x19",
+        PageSize.Square_12x12 => "12x12",
         _ => PageSpec.Size.ToString()
     };
 }

--- a/CalendarMaker-MAUI/Models/PageSizes.cs
+++ b/CalendarMaker-MAUI/Models/PageSizes.cs
@@ -19,6 +19,7 @@ public static class PageSizes
             PageSize.Letter => (8.5, 11.0),
             PageSize.Tabloid_11x17 => (11.0, 17.0),
             PageSize.SuperB_13x19 => (13.0, 19.0),
+            PageSize.Square_12x12 => (12.0, 12.0),
             PageSize.Custom => (0, 0),
             _ => (8.5, 11.0)
         };

--- a/CalendarMaker-MAUI/Models/PageSpec.cs
+++ b/CalendarMaker-MAUI/Models/PageSpec.cs
@@ -33,7 +33,16 @@ public enum PageSize
     /// <summary>
     /// Custom page size with user-defined dimensions.
     /// </summary>
-    Custom
+    Custom,
+
+    /// <summary>
+    /// 12x12 inch square page size (classic wall/scrapbook calendar).
+    /// </summary>
+    /// <remarks>
+    /// Declared last so its serialized integer value stays stable and does not
+    /// shift the values of the pre-existing members in saved projects.
+    /// </remarks>
+    Square_12x12
 }
 
 /// <summary>

--- a/CalendarMaker-MAUI/Views/NewProjectModal.xaml
+++ b/CalendarMaker-MAUI/Views/NewProjectModal.xaml
@@ -14,6 +14,7 @@
                     <x:String>Letter Portrait</x:String>
                     <x:String>11x17 Portrait</x:String>
                     <x:String>13x19 Portrait</x:String>
+                    <x:String>12x12 Square</x:String>
                 </Picker.Items>
             </Picker>
         </VerticalStackLayout>

--- a/CalendarMaker-MAUI/Views/NewProjectModal.xaml.cs
+++ b/CalendarMaker-MAUI/Views/NewProjectModal.xaml.cs
@@ -32,6 +32,7 @@ public partial class NewProjectModal : ContentPage
             1 => "Letter Portrait 50/50 (Photo Top)",
             2 => "11x17 Portrait 60/40 (Photo Top)",
             3 => "13x19 Portrait 65/35 (Photo Top)",
+            4 => "12x12 Square 50/50 (Photo Top)",
             _ => "5x7 Landscape 50/50 (Photo Left)"
         };
 

--- a/CalendarMaker-MAUI/Views/ProjectSettingsModal.xaml.cs
+++ b/CalendarMaker-MAUI/Views/ProjectSettingsModal.xaml.cs
@@ -20,7 +20,8 @@ public partial class ProjectSettingsModal : ContentPage
             "5×7 inches",
             "Letter (8.5×11 inches)",
             "Tabloid/Ledger (11×17 inches)",
-            "Super B (13×19 inches)"
+            "Super B (13×19 inches)",
+            "12x12 inches (square)"
         };
 
         // Set current page size
@@ -30,6 +31,7 @@ public partial class ProjectSettingsModal : ContentPage
             PageSize.Letter => 1,
             PageSize.Tabloid_11x17 => 2,
             PageSize.SuperB_13x19 => 3,
+            PageSize.Square_12x12 => 4,
             _ => 1 // Default to Letter
         };
 
@@ -209,6 +211,7 @@ public partial class ProjectSettingsModal : ContentPage
                 0 => PageSize.FiveBySeven,
                 2 => PageSize.Tabloid_11x17,
                 3 => PageSize.SuperB_13x19,
+                4 => PageSize.Square_12x12,
                 _ => PageSize.Letter
             };
 

--- a/CalendarMaker-MAUI/Views/ProjectsPage.xaml.cs
+++ b/CalendarMaker-MAUI/Views/ProjectsPage.xaml.cs
@@ -87,6 +87,13 @@ public partial class ProjectsPage : ContentPage
             project.LayoutSpec.Placement = LayoutPlacement.PhotoTopCalendarBottom;
             project.LayoutSpec.SplitRatio = 0.65;
         }
+        else if (preset.StartsWith("12x12"))
+        {
+            project.PageSpec.Size = PageSize.Square_12x12;
+            project.PageSpec.Orientation = PageOrientation.Portrait;
+            project.LayoutSpec.Placement = LayoutPlacement.PhotoTopCalendarBottom;
+            project.LayoutSpec.SplitRatio = 0.5;
+        }
         else
         {
             project.PageSpec.Size = PageSize.Letter;


### PR DESCRIPTION
Closes #54

## What
Adds a **12"×12" square** page size — the classic wall/scrapbook calendar format — as a first-class option throughout the app.

## Changes
- `PageSize.Square_12x12` enum value, **appended last** so the integer values of existing enum members (and thus existing saved `project.json` files, which serialize enums as integers) are unchanged.
- `PageSizes.GetInches` returns `(12.0, 12.0)`.
- `CalendarProject.PageSizeDisplay` shows `"12x12"`.
- Selectable in the **Project Settings** page-size picker.
- Available as a **"12x12 Square"** preset in the **New Project** modal (defaults to Photo-Top / Calendar-Bottom, 50/50 split).

`LayoutService.ApplyDefaultPreset` already falls back to Photo-Top / 0.5 split, which is the desired default for a square page, so no change was needed there.

## Testing
- `dotnet build` (all target frameworks): 0 errors.
- `dotnet test`: 30/30 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)