### PR TITLE
Increase unit test coverage (#56)

### DIFF
--- a/CalendarMaker-MAUI/Services/ProjectStorageService.cs
+++ b/CalendarMaker-MAUI/Services/ProjectStorageService.cs
@@ -17,8 +17,18 @@ public sealed class ProjectStorageService : IProjectStorageService
     private readonly string _root;
 
     public ProjectStorageService()
+        : this(Path.Combine(FileSystem.Current.AppDataDirectory, "Projects"))
     {
-        _root = Path.Combine(FileSystem.Current.AppDataDirectory, "Projects");
+    }
+
+    /// <summary>
+    /// Creates a storage service rooted at an explicit directory. Primarily a testability seam;
+    /// the parameterless constructor uses the platform app-data directory.
+    /// </summary>
+    /// <param name="rootDirectory">The directory under which project folders are stored.</param>
+    public ProjectStorageService(string rootDirectory)
+    {
+        _root = rootDirectory;
         Directory.CreateDirectory(_root);
     }
 

--- a/CalendarMaker.Tests/Models/CalendarProjectTests.cs
+++ b/CalendarMaker.Tests/Models/CalendarProjectTests.cs
@@ -1,0 +1,44 @@
+using CalendarMaker_MAUI.Models;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Models;
+
+/// <summary>
+/// Tests for computed members on <see cref="CalendarProject"/>.
+/// </summary>
+public class CalendarProjectTests
+{
+    private static CalendarProject WithSize(PageSize size) => new()
+    {
+        PageSpec = new PageSpec { Size = size }
+    };
+
+    [Theory]
+    [InlineData(PageSize.FiveBySeven, "5x7")]
+    [InlineData(PageSize.Letter, "Letter")]
+    [InlineData(PageSize.Tabloid_11x17, "11x17")]
+    [InlineData(PageSize.SuperB_13x19, "13x19")]
+    public void PageSizeDisplay_KnownSizes_ReturnFriendlyLabels(PageSize size, string expected)
+    {
+        WithSize(size).PageSizeDisplay.Should().Be(expected);
+    }
+
+    [Fact]
+    public void PageSizeDisplay_UnmappedSize_FallsBackToEnumName()
+    {
+        // A4 has no explicit label and should fall back to the enum name.
+        WithSize(PageSize.A4).PageSizeDisplay.Should().Be("A4");
+    }
+
+    [Fact]
+    public void NewProject_HasInitializedCollectionsAndDefaults()
+    {
+        var project = new CalendarProject();
+
+        project.ImageAssets.Should().NotBeNull().And.BeEmpty();
+        project.MonthPhotoLayouts.Should().NotBeNull().And.BeEmpty();
+        project.PageSpec.Should().NotBeNull();
+        project.LayoutSpec.Should().NotBeNull();
+        project.Id.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/CalendarMaker.Tests/Models/PageSizesTests.cs
+++ b/CalendarMaker.Tests/Models/PageSizesTests.cs
@@ -1,0 +1,83 @@
+using CalendarMaker_MAUI.Models;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Models;
+
+/// <summary>
+/// Tests for <see cref="PageSizes"/> dimension lookups and point conversion.
+/// </summary>
+public class PageSizesTests
+{
+    [Theory]
+    [InlineData(PageSize.FiveBySeven, 5.0, 7.0)]
+    [InlineData(PageSize.A4, 8.27, 11.69)]
+    [InlineData(PageSize.Letter, 8.5, 11.0)]
+    [InlineData(PageSize.Tabloid_11x17, 11.0, 17.0)]
+    [InlineData(PageSize.SuperB_13x19, 13.0, 19.0)]
+    [InlineData(PageSize.Custom, 0.0, 0.0)]
+    public void GetInches_ReturnsExpectedDimensions(PageSize size, double expectedW, double expectedH)
+    {
+        var (w, h) = PageSizes.GetInches(size);
+
+        w.Should().Be(expectedW);
+        h.Should().Be(expectedH);
+    }
+
+    [Fact]
+    public void GetPoints_LetterPortrait_ConvertsInchesToPoints()
+    {
+        var spec = new PageSpec { Size = PageSize.Letter, Orientation = PageOrientation.Portrait };
+
+        var (w, h) = PageSizes.GetPoints(spec);
+
+        w.Should().BeApproximately(8.5 * 72.0, 0.001);  // 612
+        h.Should().BeApproximately(11.0 * 72.0, 0.001);  // 792
+    }
+
+    [Fact]
+    public void GetPoints_Landscape_SwapsWidthAndHeight()
+    {
+        var portrait = new PageSpec { Size = PageSize.Letter, Orientation = PageOrientation.Portrait };
+        var landscape = new PageSpec { Size = PageSize.Letter, Orientation = PageOrientation.Landscape };
+
+        var (pw, ph) = PageSizes.GetPoints(portrait);
+        var (lw, lh) = PageSizes.GetPoints(landscape);
+
+        lw.Should().BeApproximately(ph, 0.001);
+        lh.Should().BeApproximately(pw, 0.001);
+    }
+
+    [Fact]
+    public void GetPoints_CustomWithDimensions_UsesCustomValues()
+    {
+        var spec = new PageSpec
+        {
+            Size = PageSize.Custom,
+            CustomWidthPt = 500,
+            CustomHeightPt = 650
+        };
+
+        var (w, h) = PageSizes.GetPoints(spec);
+
+        w.Should().Be(500);
+        h.Should().Be(650);
+    }
+
+    [Fact]
+    public void GetPoints_CustomWithDimensions_IgnoresOrientationSwap()
+    {
+        // Custom dimensions are taken verbatim and not swapped for landscape.
+        var spec = new PageSpec
+        {
+            Size = PageSize.Custom,
+            CustomWidthPt = 500,
+            CustomHeightPt = 650,
+            Orientation = PageOrientation.Landscape
+        };
+
+        var (w, h) = PageSizes.GetPoints(spec);
+
+        w.Should().Be(500);
+        h.Should().Be(650);
+    }
+}

--- a/CalendarMaker.Tests/Services/AssetServiceTests.cs
+++ b/CalendarMaker.Tests/Services/AssetServiceTests.cs
@@ -1,0 +1,158 @@
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+using Moq;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// Tests for the in-memory asset assignment logic in <see cref="AssetService"/>.
+/// File-copying paths that require the MAUI filesystem are out of scope here; these
+/// tests exercise the pure project-manipulation behavior with a mocked storage service.
+/// </summary>
+public class AssetServiceTests
+{
+    private readonly Mock<IProjectStorageService> _storage = new();
+    private readonly AssetService _service;
+
+    public AssetServiceTests()
+    {
+        _service = new AssetService(_storage.Object);
+    }
+
+    private static CalendarProject ProjectWith(params ImageAsset[] assets)
+    {
+        var project = new CalendarProject { Id = "proj-1" };
+        project.ImageAssets.AddRange(assets);
+        return project;
+    }
+
+    [Fact]
+    public async Task AssignPhotoToSlotAsync_MonthPhoto_AddsAssetAndSavesProject()
+    {
+        var source = new ImageAsset { Id = "src", Role = "unassigned", Path = "a.jpg" };
+        var project = ProjectWith(source);
+
+        await _service.AssignPhotoToSlotAsync(project, "src", monthIndex: 3, slotIndex: 0, role: "monthPhoto");
+
+        var assigned = project.ImageAssets.SingleOrDefault(a => a.Role == "monthPhoto");
+        assigned.Should().NotBeNull();
+        assigned!.MonthIndex.Should().Be(3);
+        assigned.SlotIndex.Should().Be(0);
+        assigned.Path.Should().Be("a.jpg"); // reuses the source file
+        _storage.Verify(s => s.UpdateProjectAsync(project), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task AssignPhotoToSlotAsync_CoverPhoto_LeavesMonthIndexNull()
+    {
+        var source = new ImageAsset { Id = "src", Role = "unassigned", Path = "cover.jpg" };
+        var project = ProjectWith(source);
+
+        await _service.AssignPhotoToSlotAsync(project, "src", monthIndex: 0, slotIndex: 1, role: "coverPhoto");
+
+        var cover = project.ImageAssets.Single(a => a.Role == "coverPhoto");
+        cover.MonthIndex.Should().BeNull();
+        cover.SlotIndex.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AssignPhotoToSlotAsync_UnknownAssetId_DoesNothing()
+    {
+        var project = ProjectWith(new ImageAsset { Id = "src", Role = "unassigned" });
+
+        await _service.AssignPhotoToSlotAsync(project, "missing", monthIndex: 0, slotIndex: 0);
+
+        project.ImageAssets.Should().HaveCount(1);
+        _storage.Verify(s => s.UpdateProjectAsync(It.IsAny<CalendarProject>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AssignPhotoToSlotAsync_ReplacesExistingPhotoInSameMonthSlot()
+    {
+        var source = new ImageAsset { Id = "src", Role = "unassigned", Path = "new.jpg" };
+        var existing = new ImageAsset { Id = "old", Role = "monthPhoto", MonthIndex = 2, SlotIndex = 0, Path = "old.jpg" };
+        var project = ProjectWith(source, existing);
+
+        await _service.AssignPhotoToSlotAsync(project, "src", monthIndex: 2, slotIndex: 0, role: "monthPhoto");
+
+        project.ImageAssets.Should().NotContain(a => a.Id == "old");
+        project.ImageAssets.Count(a => a.Role == "monthPhoto" && a.MonthIndex == 2 && (a.SlotIndex ?? 0) == 0)
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public async Task RemovePhotoFromSlotAsync_RemovesMatchingAssetAndSaves()
+    {
+        var asset = new ImageAsset { Id = "m", Role = "monthPhoto", MonthIndex = 5, SlotIndex = 0 };
+        var project = ProjectWith(asset);
+
+        await _service.RemovePhotoFromSlotAsync(project, monthIndex: 5, slotIndex: 0, role: "monthPhoto");
+
+        project.ImageAssets.Should().BeEmpty();
+        _storage.Verify(s => s.UpdateProjectAsync(project), Times.Once);
+    }
+
+    [Fact]
+    public async Task RemovePhotoFromSlotAsync_NoMatch_DoesNotSave()
+    {
+        var asset = new ImageAsset { Id = "m", Role = "monthPhoto", MonthIndex = 5, SlotIndex = 0 };
+        var project = ProjectWith(asset);
+
+        await _service.RemovePhotoFromSlotAsync(project, monthIndex: 6, slotIndex: 0, role: "monthPhoto");
+
+        project.ImageAssets.Should().HaveCount(1);
+        _storage.Verify(s => s.UpdateProjectAsync(It.IsAny<CalendarProject>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetUnassignedPhotosAsync_ReturnsOnlyUnassigned()
+    {
+        var project = ProjectWith(
+            new ImageAsset { Id = "u1", Role = "unassigned" },
+            new ImageAsset { Id = "m1", Role = "monthPhoto", MonthIndex = 0 },
+            new ImageAsset { Id = "u2", Role = "unassigned" });
+
+        var result = await _service.GetUnassignedPhotosAsync(project);
+
+        result.Should().OnlyContain(a => a.Role == "unassigned");
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetAllPhotosAsync_ReturnsEveryAsset()
+    {
+        var project = ProjectWith(
+            new ImageAsset { Id = "u1", Role = "unassigned" },
+            new ImageAsset { Id = "m1", Role = "monthPhoto" });
+
+        var result = await _service.GetAllPhotosAsync(project);
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DeletePhotoFromProjectAsync_RemovesAllAssetsSharingPathAndSaves()
+    {
+        var project = ProjectWith(
+            new ImageAsset { Id = "a", Role = "unassigned", Path = "shared.jpg" },
+            new ImageAsset { Id = "b", Role = "monthPhoto", MonthIndex = 1, Path = "shared.jpg" },
+            new ImageAsset { Id = "c", Role = "monthPhoto", MonthIndex = 2, Path = "other.jpg" });
+
+        await _service.DeletePhotoFromProjectAsync(project, "shared.jpg");
+
+        project.ImageAssets.Select(a => a.Id).Should().BeEquivalentTo(new[] { "c" });
+        _storage.Verify(s => s.UpdateProjectAsync(project), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeletePhotoFromProjectAsync_BlankPath_DoesNothing()
+    {
+        var project = ProjectWith(new ImageAsset { Id = "a", Path = "x.jpg" });
+
+        await _service.DeletePhotoFromProjectAsync(project, "  ");
+
+        project.ImageAssets.Should().HaveCount(1);
+        _storage.Verify(s => s.UpdateProjectAsync(It.IsAny<CalendarProject>()), Times.Never);
+    }
+}

--- a/CalendarMaker.Tests/Services/CalendarEngineTests.cs
+++ b/CalendarMaker.Tests/Services/CalendarEngineTests.cs
@@ -1,0 +1,104 @@
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="CalendarEngine"/>, which builds the week/day matrix for a month.
+/// </summary>
+public class CalendarEngineTests
+{
+    private readonly CalendarEngine _engine = new();
+
+    [Fact]
+    public void BuildMonthGrid_EveryWeekHasSevenDays()
+    {
+        var weeks = _engine.BuildMonthGrid(2025, 1, DayOfWeek.Sunday);
+
+        weeks.Should().OnlyContain(week => week.Count == 7);
+    }
+
+    [Fact]
+    public void BuildMonthGrid_ContainsEveryDayOfMonthExactlyOnce()
+    {
+        var weeks = _engine.BuildMonthGrid(2025, 1, DayOfWeek.Sunday);
+
+        var days = weeks.SelectMany(w => w)
+            .Where(d => d.HasValue && d.Value.Month == 1)
+            .Select(d => d!.Value.Day)
+            .ToList();
+
+        days.Should().BeEquivalentTo(Enumerable.Range(1, 31));
+    }
+
+    [Fact]
+    public void BuildMonthGrid_January2025_SundayStart_HasThreeLeadingNulls()
+    {
+        // Jan 1 2025 falls on a Wednesday; with a Sunday start that is offset 3.
+        var weeks = _engine.BuildMonthGrid(2025, 1, DayOfWeek.Sunday);
+
+        var firstWeek = weeks[0];
+        firstWeek[0].Should().BeNull();
+        firstWeek[1].Should().BeNull();
+        firstWeek[2].Should().BeNull();
+        firstWeek[3].Should().Be(new DateTime(2025, 1, 1));
+        firstWeek[6].Should().Be(new DateTime(2025, 1, 4));
+    }
+
+    [Fact]
+    public void BuildMonthGrid_January2025_MondayStart_ShiftsLeadingNulls()
+    {
+        // Jan 1 2025 is a Wednesday; with a Monday start that is offset 2.
+        var weeks = _engine.BuildMonthGrid(2025, 1, DayOfWeek.Monday);
+
+        weeks[0][0].Should().BeNull();
+        weeks[0][1].Should().BeNull();
+        weeks[0][2].Should().Be(new DateTime(2025, 1, 1));
+    }
+
+    [Fact]
+    public void BuildMonthGrid_LeapYearFebruary_Includes29Days()
+    {
+        var weeks = _engine.BuildMonthGrid(2024, 2, DayOfWeek.Sunday);
+
+        var maxDay = weeks.SelectMany(w => w)
+            .Where(d => d.HasValue && d.Value.Month == 2)
+            .Max(d => d!.Value.Day);
+
+        maxDay.Should().Be(29);
+    }
+
+    [Fact]
+    public void BuildMonthGrid_NonLeapYearFebruary_Includes28Days()
+    {
+        var weeks = _engine.BuildMonthGrid(2025, 2, DayOfWeek.Sunday);
+
+        var maxDay = weeks.SelectMany(w => w)
+            .Where(d => d.HasValue && d.Value.Month == 2)
+            .Max(d => d!.Value.Day);
+
+        maxDay.Should().Be(28);
+    }
+
+    [Theory]
+    [InlineData(2025, 1)]
+    [InlineData(2025, 2)]
+    [InlineData(2024, 2)]
+    [InlineData(2025, 12)]
+    [InlineData(2026, 3)]
+    public void BuildMonthGrid_ProducesBetweenFourAndSixWeeks(int year, int month)
+    {
+        var weeks = _engine.BuildMonthGrid(year, month, DayOfWeek.Sunday);
+
+        weeks.Count.Should().BeInRange(4, 6);
+    }
+
+    [Fact]
+    public void BuildMonthGrid_FirstWeekOfMonthWithNoOffset_StartsOnDayOne()
+    {
+        // June 1 2025 is a Sunday, so with a Sunday start there is no leading padding.
+        var weeks = _engine.BuildMonthGrid(2025, 6, DayOfWeek.Sunday);
+
+        weeks[0][0].Should().Be(new DateTime(2025, 6, 1));
+    }
+}

--- a/CalendarMaker.Tests/Services/LayoutCalculatorTests.cs
+++ b/CalendarMaker.Tests/Services/LayoutCalculatorTests.cs
@@ -1,0 +1,137 @@
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+using SkiaSharp;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="LayoutCalculator"/>, which computes photo slot rectangles
+/// and the photo/calendar split for a page.
+/// </summary>
+public class LayoutCalculatorTests
+{
+    private const float Tolerance = 0.001f;
+    private readonly LayoutCalculator _calc = new();
+    private static readonly SKRect Area = new(0, 0, 400, 300);
+
+    [Theory]
+    [InlineData(PhotoLayout.Single, 1)]
+    [InlineData(PhotoLayout.TwoVerticalSplit, 2)]
+    [InlineData(PhotoLayout.Grid2x2, 4)]
+    [InlineData(PhotoLayout.TwoHorizontalStack, 2)]
+    [InlineData(PhotoLayout.ThreeLeftStack, 3)]
+    [InlineData(PhotoLayout.ThreeRightStack, 3)]
+    public void ComputePhotoSlots_ReturnsExpectedSlotCount(PhotoLayout layout, int expectedCount)
+    {
+        var slots = _calc.ComputePhotoSlots(Area, layout);
+
+        slots.Should().HaveCount(expectedCount);
+    }
+
+    [Fact]
+    public void ComputePhotoSlots_Single_ReturnsWholeArea()
+    {
+        var slots = _calc.ComputePhotoSlots(Area, PhotoLayout.Single);
+
+        slots[0].Should().Be(Area);
+    }
+
+    [Fact]
+    public void ComputePhotoSlots_AllSlotsStayWithinArea()
+    {
+        foreach (PhotoLayout layout in Enum.GetValues<PhotoLayout>())
+        {
+            var slots = _calc.ComputePhotoSlots(Area, layout);
+            foreach (var slot in slots)
+            {
+                slot.Left.Should().BeGreaterThanOrEqualTo(Area.Left - Tolerance);
+                slot.Top.Should().BeGreaterThanOrEqualTo(Area.Top - Tolerance);
+                slot.Right.Should().BeLessThanOrEqualTo(Area.Right + Tolerance);
+                slot.Bottom.Should().BeLessThanOrEqualTo(Area.Bottom + Tolerance);
+            }
+        }
+    }
+
+    [Fact]
+    public void ComputePhotoSlots_TwoVerticalSplit_LeavesGapBetweenColumns()
+    {
+        var slots = _calc.ComputePhotoSlots(Area, PhotoLayout.TwoVerticalSplit);
+
+        // The two columns are separated by a 4pt gap.
+        (slots[1].Left - slots[0].Right).Should().BeApproximately(4f, Tolerance);
+        slots[0].Left.Should().Be(Area.Left);
+        slots[1].Right.Should().Be(Area.Right);
+    }
+
+    [Fact]
+    public void ComputePhotoSlots_TwoHorizontalStack_LeavesGapBetweenRows()
+    {
+        var slots = _calc.ComputePhotoSlots(Area, PhotoLayout.TwoHorizontalStack);
+
+        (slots[1].Top - slots[0].Bottom).Should().BeApproximately(4f, Tolerance);
+        slots[0].Top.Should().Be(Area.Top);
+        slots[1].Bottom.Should().Be(Area.Bottom);
+    }
+
+    [Fact]
+    public void ComputeSplit_Portrait_PhotoTop_PartitionsVertically()
+    {
+        var spec = new LayoutSpec { Placement = LayoutPlacement.PhotoTopCalendarBottom, SplitRatio = 0.5 };
+        var page = new PageSpec { Orientation = PageOrientation.Portrait };
+
+        var (photo, calendar) = _calc.ComputeSplit(Area, spec, page);
+
+        photo.Top.Should().Be(Area.Top);
+        photo.Bottom.Should().BeApproximately(Area.Top + Area.Height * 0.5f, Tolerance);
+        calendar.Top.Should().BeApproximately(photo.Bottom, Tolerance);
+        calendar.Bottom.Should().Be(Area.Bottom);
+        // Full page width used by both.
+        photo.Width.Should().BeApproximately(Area.Width, Tolerance);
+        calendar.Width.Should().BeApproximately(Area.Width, Tolerance);
+    }
+
+    [Fact]
+    public void ComputeSplit_Landscape_NormalizesVerticalPlacementToHorizontal()
+    {
+        // PhotoTopCalendarBottom in landscape becomes PhotoLeftCalendarRight.
+        var spec = new LayoutSpec { Placement = LayoutPlacement.PhotoTopCalendarBottom, SplitRatio = 0.5 };
+        var page = new PageSpec { Orientation = PageOrientation.Landscape };
+
+        var (photo, calendar) = _calc.ComputeSplit(Area, spec, page);
+
+        photo.Left.Should().Be(Area.Left);
+        photo.Right.Should().BeApproximately(Area.Left + Area.Width * 0.5f, Tolerance);
+        calendar.Left.Should().BeApproximately(photo.Right, Tolerance);
+        calendar.Right.Should().Be(Area.Right);
+        photo.Height.Should().BeApproximately(Area.Height, Tolerance);
+    }
+
+    [Fact]
+    public void ComputeSplit_Portrait_NormalizesHorizontalPlacementToVertical()
+    {
+        // PhotoLeftCalendarRight in portrait becomes PhotoTopCalendarBottom.
+        var spec = new LayoutSpec { Placement = LayoutPlacement.PhotoLeftCalendarRight, SplitRatio = 0.5 };
+        var page = new PageSpec { Orientation = PageOrientation.Portrait };
+
+        var (photo, calendar) = _calc.ComputeSplit(Area, spec, page);
+
+        photo.Width.Should().BeApproximately(Area.Width, Tolerance);
+        photo.Bottom.Should().BeApproximately(Area.Top + Area.Height * 0.5f, Tolerance);
+        calendar.Top.Should().BeApproximately(photo.Bottom, Tolerance);
+    }
+
+    [Theory]
+    [InlineData(0.05, 0.1)] // clamped up to the minimum
+    [InlineData(0.95, 0.9)] // clamped down to the maximum
+    [InlineData(0.7, 0.7)]  // within range, unchanged
+    public void ComputeSplit_ClampsRatioBetweenTenthAndNinetieth(double ratio, double effectiveRatio)
+    {
+        var spec = new LayoutSpec { Placement = LayoutPlacement.PhotoTopCalendarBottom, SplitRatio = ratio };
+        var page = new PageSpec { Orientation = PageOrientation.Portrait };
+
+        var (photo, _) = _calc.ComputeSplit(Area, spec, page);
+
+        photo.Height.Should().BeApproximately(Area.Height * (float)effectiveRatio, Tolerance);
+    }
+}

--- a/CalendarMaker.Tests/Services/LayoutServiceTests.cs
+++ b/CalendarMaker.Tests/Services/LayoutServiceTests.cs
@@ -1,0 +1,76 @@
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="LayoutService.ApplyDefaultPreset"/>, which chooses a sensible
+/// default placement and split ratio for a page size + orientation.
+/// </summary>
+public class LayoutServiceTests
+{
+    private readonly LayoutService _service = new();
+
+    private static CalendarProject ProjectWith(PageSize size, PageOrientation orientation) => new()
+    {
+        PageSpec = new PageSpec { Size = size, Orientation = orientation },
+        LayoutSpec = new LayoutSpec()
+    };
+
+    [Fact]
+    public void ApplyDefaultPreset_FiveBySevenLandscape_UsesPhotoLeft()
+    {
+        var project = ProjectWith(PageSize.FiveBySeven, PageOrientation.Landscape);
+
+        _service.ApplyDefaultPreset(project);
+
+        project.LayoutSpec.Placement.Should().Be(LayoutPlacement.PhotoLeftCalendarRight);
+        project.LayoutSpec.SplitRatio.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void ApplyDefaultPreset_LetterPortrait_UsesPhotoTopHalfSplit()
+    {
+        var project = ProjectWith(PageSize.Letter, PageOrientation.Portrait);
+
+        _service.ApplyDefaultPreset(project);
+
+        project.LayoutSpec.Placement.Should().Be(LayoutPlacement.PhotoTopCalendarBottom);
+        project.LayoutSpec.SplitRatio.Should().Be(0.5);
+    }
+
+    [Fact]
+    public void ApplyDefaultPreset_TabloidPortrait_UsesSixtyFortySplit()
+    {
+        var project = ProjectWith(PageSize.Tabloid_11x17, PageOrientation.Portrait);
+
+        _service.ApplyDefaultPreset(project);
+
+        project.LayoutSpec.Placement.Should().Be(LayoutPlacement.PhotoTopCalendarBottom);
+        project.LayoutSpec.SplitRatio.Should().Be(0.6);
+    }
+
+    [Fact]
+    public void ApplyDefaultPreset_SuperBPortrait_UsesSixtyFiveSplit()
+    {
+        var project = ProjectWith(PageSize.SuperB_13x19, PageOrientation.Portrait);
+
+        _service.ApplyDefaultPreset(project);
+
+        project.LayoutSpec.Placement.Should().Be(LayoutPlacement.PhotoTopCalendarBottom);
+        project.LayoutSpec.SplitRatio.Should().Be(0.65);
+    }
+
+    [Fact]
+    public void ApplyDefaultPreset_UnmatchedCombination_FallsBackToPhotoTopHalfSplit()
+    {
+        // A4 portrait has no explicit rule, so it should hit the sensible fallback.
+        var project = ProjectWith(PageSize.A4, PageOrientation.Portrait);
+
+        _service.ApplyDefaultPreset(project);
+
+        project.LayoutSpec.Placement.Should().Be(LayoutPlacement.PhotoTopCalendarBottom);
+        project.LayoutSpec.SplitRatio.Should().Be(0.5);
+    }
+}

--- a/CalendarMaker.Tests/Services/ProjectStorageServiceTests.cs
+++ b/CalendarMaker.Tests/Services/ProjectStorageServiceTests.cs
@@ -1,0 +1,124 @@
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// File-backed tests for <see cref="ProjectStorageService"/> using an isolated temp directory
+/// (via the root-directory constructor seam) so no MAUI app-data context is required.
+/// </summary>
+public class ProjectStorageServiceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly ProjectStorageService _storage;
+
+    public ProjectStorageServiceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "CalendarMakerTests", Guid.NewGuid().ToString("N"));
+        _storage = new ProjectStorageService(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort cleanup */ }
+    }
+
+    private static CalendarProject NewProject(string name = "Test") => new()
+    {
+        Name = name,
+        Year = 2025,
+        PageSpec = new PageSpec { Size = PageSize.Letter }
+    };
+
+    [Fact]
+    public async Task CreateProjectAsync_AssignsIdAndPersistsToDisk()
+    {
+        var project = NewProject();
+
+        string id = await _storage.CreateProjectAsync(project);
+
+        id.Should().NotBeNullOrWhiteSpace();
+        project.Id.Should().Be(id);
+        File.Exists(Path.Combine(_root, id, "project.json")).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetProjectsAsync_ReturnsAllPersistedProjects()
+    {
+        await _storage.CreateProjectAsync(NewProject("A"));
+        await _storage.CreateProjectAsync(NewProject("B"));
+
+        var projects = await _storage.GetProjectsAsync();
+
+        projects.Should().HaveCount(2);
+        projects.Select(p => p.Name).Should().BeEquivalentTo(new[] { "A", "B" });
+    }
+
+    [Fact]
+    public async Task GetProjectsAsync_EmptyRoot_ReturnsEmpty()
+    {
+        var projects = await _storage.GetProjectsAsync();
+
+        projects.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RoundTrip_PreservesProjectData()
+    {
+        var project = NewProject("Round Trip");
+        project.StartMonth = 6;
+        project.LayoutSpec.SplitRatio = 0.65;
+        await _storage.CreateProjectAsync(project);
+
+        var loaded = (await _storage.GetProjectsAsync()).Single();
+
+        loaded.Name.Should().Be("Round Trip");
+        loaded.Year.Should().Be(2025);
+        loaded.StartMonth.Should().Be(6);
+        loaded.LayoutSpec.SplitRatio.Should().Be(0.65);
+        loaded.PageSpec.Size.Should().Be(PageSize.Letter);
+    }
+
+    [Fact]
+    public async Task UpdateProjectAsync_PersistsChangesAndStampsUpdatedUtc()
+    {
+        var project = NewProject("Original");
+        await _storage.CreateProjectAsync(project);
+        DateTime beforeUpdate = DateTime.UtcNow;
+
+        project.Name = "Renamed";
+        await _storage.UpdateProjectAsync(project);
+
+        var loaded = (await _storage.GetProjectsAsync()).Single();
+        loaded.Name.Should().Be("Renamed");
+        loaded.UpdatedUtc.Should().BeOnOrAfter(beforeUpdate.AddSeconds(-1));
+    }
+
+    [Fact]
+    public async Task DeleteProjectAsync_RemovesTheProjectDirectory()
+    {
+        string id = await _storage.CreateProjectAsync(NewProject());
+
+        await _storage.DeleteProjectAsync(id);
+
+        Directory.Exists(Path.Combine(_root, id)).Should().BeFalse();
+        (await _storage.GetProjectsAsync()).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DeleteProjectAsync_UnknownId_DoesNotThrow()
+    {
+        var act = async () => await _storage.DeleteProjectAsync("does-not-exist");
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public void GetProjectDirectory_ReturnsPathUnderRoot()
+    {
+        string dir = _storage.GetProjectDirectory("abc123");
+
+        dir.Should().Be(Path.Combine(_root, "abc123"));
+    }
+}

--- a/CalendarMaker.Tests/Services/TemplateServiceTests.cs
+++ b/CalendarMaker.Tests/Services/TemplateServiceTests.cs
@@ -1,0 +1,47 @@
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="TemplateService"/>, the registry of dev-authored templates.
+/// </summary>
+public class TemplateServiceTests
+{
+    private readonly TemplateService _service = new();
+
+    [Fact]
+    public void GetTemplateKeys_ContainsBuiltInTemplates()
+    {
+        var keys = _service.GetTemplateKeys().ToList();
+
+        keys.Should().Contain("PhotoMonthlyClassic");
+        keys.Should().Contain("PhotoCover");
+    }
+
+    [Fact]
+    public void DefaultTemplateKey_IsRegistered()
+    {
+        var keys = _service.GetTemplateKeys();
+
+        keys.Should().Contain(TemplateService.DefaultTemplateKey);
+    }
+
+    [Fact]
+    public void GetTemplate_KnownKey_ReturnsMatchingDescriptor()
+    {
+        var template = _service.GetTemplate("PhotoMonthlyClassic");
+
+        template.Key.Should().Be("PhotoMonthlyClassic");
+        template.Name.Should().Be("Photo Monthly Classic");
+        template.Description.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void GetTemplate_UnknownKey_Throws()
+    {
+        var act = () => _service.GetTemplate("does-not-exist");
+
+        act.Should().Throw<KeyNotFoundException>();
+    }
+}

--- a/CalendarMaker.Tests/ViewModels/ProjectsViewModelTests.cs
+++ b/CalendarMaker.Tests/ViewModels/ProjectsViewModelTests.cs
@@ -1,0 +1,92 @@
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+using CalendarMaker_MAUI.ViewModels;
+using FluentAssertions;
+using Moq;
+
+namespace CalendarMaker.Tests.ViewModels;
+
+/// <summary>
+/// Tests for <see cref="ProjectsViewModel"/> using a mocked storage service and the real
+/// (pure) <see cref="LayoutService"/>.
+/// </summary>
+public class ProjectsViewModelTests
+{
+    private readonly Mock<IProjectStorageService> _storage = new();
+    private readonly LayoutService _layoutService = new();
+    private readonly ProjectsViewModel _viewModel;
+
+    public ProjectsViewModelTests()
+    {
+        _viewModel = new ProjectsViewModel(_storage.Object, _layoutService);
+    }
+
+    [Fact]
+    public async Task LoadAsync_PopulatesProjectsFromStorage()
+    {
+        var stored = new List<CalendarProject>
+        {
+            new() { Name = "One" },
+            new() { Name = "Two" }
+        };
+        _storage.Setup(s => s.GetProjectsAsync()).ReturnsAsync(stored);
+
+        await _viewModel.LoadAsync();
+
+        _viewModel.Projects.Should().HaveCount(2);
+        _viewModel.Projects.Select(p => p.Name).Should().BeEquivalentTo(new[] { "One", "Two" });
+    }
+
+    [Fact]
+    public async Task CreateDefaultProjectAsync_CreatesLandscapeFiveBySevenAndReloads()
+    {
+        CalendarProject? created = null;
+        _storage.Setup(s => s.CreateProjectAsync(It.IsAny<CalendarProject>()))
+            .Callback<CalendarProject>(p => created = p)
+            .ReturnsAsync("new-id");
+        _storage.Setup(s => s.GetProjectsAsync()).ReturnsAsync(new List<CalendarProject>());
+
+        await _viewModel.CreateDefaultProjectAsync();
+
+        created.Should().NotBeNull();
+        created!.Name.Should().Be("My Calendar");
+        created.PageSpec.Size.Should().Be(PageSize.FiveBySeven);
+        created.PageSpec.Orientation.Should().Be(PageOrientation.Landscape);
+        // LayoutService should have applied the 5x7 landscape preset.
+        created.LayoutSpec.Placement.Should().Be(LayoutPlacement.PhotoLeftCalendarRight);
+        _storage.Verify(s => s.GetProjectsAsync(), Times.Once); // reload after create
+    }
+
+    [Fact]
+    public async Task CreateSpecificProjectAsync_AppliesPresetPersistsAndReloads()
+    {
+        var project = new CalendarProject
+        {
+            Name = "Custom",
+            PageSpec = new PageSpec { Size = PageSize.Tabloid_11x17, Orientation = PageOrientation.Portrait }
+        };
+        _storage.Setup(s => s.CreateProjectAsync(project)).ReturnsAsync("id");
+        _storage.Setup(s => s.GetProjectsAsync()).ReturnsAsync(new List<CalendarProject> { project });
+
+        await _viewModel.CreateSpecificProjectAsync(project);
+
+        // Tabloid portrait preset => photo top, 60/40 split.
+        project.LayoutSpec.Placement.Should().Be(LayoutPlacement.PhotoTopCalendarBottom);
+        project.LayoutSpec.SplitRatio.Should().Be(0.6);
+        _storage.Verify(s => s.CreateProjectAsync(project), Times.Once);
+        _viewModel.Projects.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task DeleteProjectAsync_DeletesByIdAndReloads()
+    {
+        var project = new CalendarProject { Id = "del-1", Name = "Doomed" };
+        _storage.Setup(s => s.GetProjectsAsync()).ReturnsAsync(new List<CalendarProject>());
+
+        await _viewModel.DeleteProjectAsync(project);
+
+        _storage.Verify(s => s.DeleteProjectAsync("del-1"), Times.Once);
+        _storage.Verify(s => s.GetProjectsAsync(), Times.Once); // reload after delete
+        _viewModel.Projects.Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
Closes #56

## What
Addresses the "severe lack of unit testing" called out for the 1.0 release by adding unit tests across the service, model, and view-model layers that previously had no coverage. The suite grows from **30 → 105 tests**.

## New test files
| Area | Coverage |
| --- | --- |
| `CalendarEngineTests` | `BuildMonthGrid` — leading-offset padding, first-day-of-week variants (Sun/Mon), leap vs. non-leap February, every day present exactly once, week counts, no-offset months |
| `LayoutCalculatorTests` | `ComputePhotoSlots` slot counts + geometry for all 6 `PhotoLayout`s (gaps, in-bounds), and `ComputeSplit` orientation normalization (portrait⇄landscape) + `SplitRatio` clamping to [0.1, 0.9] |
| `LayoutServiceTests` | `ApplyDefaultPreset` placement/split for each size+orientation rule, plus the fallback path |
| `PageSizesTests` | `GetInches` for every `PageSize`; `GetPoints` inch→point conversion, landscape width/height swap, and custom dimensions |
| `CalendarProjectTests` | `PageSizeDisplay` labels + enum-name fallback; default construction invariants |
| `AssetServiceTests` | assign / replace / remove / query / delete of photo assets against a mocked `IProjectStorageService` |
| `TemplateServiceTests` | registry keys, default key, lookup, and unknown-key throwing |
| `ProjectStorageServiceTests` | file-backed create/get/update/delete/round-trip against an isolated temp directory |
| `ProjectsViewModelTests` | load / create-default / create-specific / delete flows (mocked storage + real `LayoutService`) |

## Production change
`ProjectStorageService` gains a `ProjectStorageService(string rootDirectory)` constructor as a testability seam; the existing parameterless constructor still uses the platform app-data directory. No behavior change.

All tests are deterministic and use the existing xUnit + FluentAssertions + Moq stack — no new dependencies. The storage tests use a temp directory (no MAUI runtime required).

## Testing
- `dotnet test`: **105/105 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)