### PR TITLE
Add calendar events with colors, emoji & repetition (#29)

### DIFF
--- a/CalendarMaker-MAUI/Models/CalendarEvent.cs
+++ b/CalendarMaker-MAUI/Models/CalendarEvent.cs
@@ -44,11 +44,6 @@ public sealed class CalendarEvent
     public string Title { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets an optional emoji or short symbol used to draw attention to the event.
-    /// </summary>
-    public string? Emoji { get; set; }
-
-    /// <summary>
     /// Gets or sets the accent color of the event as a hex string (e.g. "#4E79A7").
     /// </summary>
     public string ColorHex { get; set; } = "#4E79A7";

--- a/CalendarMaker-MAUI/Models/CalendarEvent.cs
+++ b/CalendarMaker-MAUI/Models/CalendarEvent.cs
@@ -1,0 +1,119 @@
+namespace CalendarMaker_MAUI.Models;
+
+/// <summary>
+/// Describes how a <see cref="CalendarEvent"/> repeats across the calendar.
+/// </summary>
+public enum EventRecurrence
+{
+    /// <summary>
+    /// Occurs once, on a single specific date (<see cref="CalendarEvent.Year"/>/<see cref="CalendarEvent.Month"/>/<see cref="CalendarEvent.Day"/>).
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Occurs every year on the same month and day (e.g. birthdays, anniversaries).
+    /// </summary>
+    Annually,
+
+    /// <summary>
+    /// Occurs every week on a given <see cref="CalendarEvent.Weekday"/>.
+    /// </summary>
+    Weekly,
+
+    /// <summary>
+    /// Occurs on the Nth (<see cref="CalendarEvent.WeekOfMonth"/>) <see cref="CalendarEvent.Weekday"/> of
+    /// <see cref="CalendarEvent.Month"/> every year (e.g. "4th Thursday of November"). This keeps
+    /// weekday-anchored holidays on the correct day as the calendar year changes.
+    /// </summary>
+    MonthlyByWeekday
+}
+
+/// <summary>
+/// A user-defined calendar event that is drawn onto the day cells of a calendar grid.
+/// </summary>
+public sealed class CalendarEvent
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for this event.
+    /// </summary>
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>
+    /// Gets or sets the event title displayed on the day cell.
+    /// </summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional emoji or short symbol used to draw attention to the event.
+    /// </summary>
+    public string? Emoji { get; set; }
+
+    /// <summary>
+    /// Gets or sets the accent color of the event as a hex string (e.g. "#4E79A7").
+    /// </summary>
+    public string ColorHex { get; set; } = "#4E79A7";
+
+    /// <summary>
+    /// Gets or sets how the event repeats.
+    /// </summary>
+    public EventRecurrence Recurrence { get; set; } = EventRecurrence.None;
+
+    /// <summary>
+    /// Gets or sets the anchor year. Only used when <see cref="Recurrence"/> is <see cref="EventRecurrence.None"/>.
+    /// </summary>
+    public int Year { get; set; }
+
+    /// <summary>
+    /// Gets or sets the anchor month (1-12). Used by <see cref="EventRecurrence.None"/>,
+    /// <see cref="EventRecurrence.Annually"/>, and <see cref="EventRecurrence.MonthlyByWeekday"/>.
+    /// </summary>
+    public int Month { get; set; }
+
+    /// <summary>
+    /// Gets or sets the anchor day of month (1-31). Used by <see cref="EventRecurrence.None"/> and
+    /// <see cref="EventRecurrence.Annually"/>.
+    /// </summary>
+    public int Day { get; set; }
+
+    /// <summary>
+    /// Gets or sets the anchor weekday. Used by <see cref="EventRecurrence.Weekly"/> and
+    /// <see cref="EventRecurrence.MonthlyByWeekday"/>.
+    /// </summary>
+    public DayOfWeek Weekday { get; set; }
+
+    /// <summary>
+    /// Gets or sets which occurrence of <see cref="Weekday"/> within the month the event falls on
+    /// (1-4, or 5 for "last"). Only used by <see cref="EventRecurrence.MonthlyByWeekday"/>.
+    /// </summary>
+    public int WeekOfMonth { get; set; } = 1;
+
+    /// <summary>
+    /// Determines whether this event occurs on the specified date.
+    /// </summary>
+    /// <param name="date">The date to test.</param>
+    /// <returns><c>true</c> if the event occurs on <paramref name="date"/>; otherwise <c>false</c>.</returns>
+    public bool OccursOn(DateTime date) => Recurrence switch
+    {
+        EventRecurrence.None => date.Year == Year && date.Month == Month && date.Day == Day,
+        EventRecurrence.Annually => date.Month == Month && date.Day == Day,
+        EventRecurrence.Weekly => date.DayOfWeek == Weekday,
+        EventRecurrence.MonthlyByWeekday => date.Month == Month
+            && date.DayOfWeek == Weekday
+            && MatchesWeekOfMonth(date),
+        _ => false
+    };
+
+    private bool MatchesWeekOfMonth(DateTime date)
+    {
+        // Which occurrence of this weekday within the month is `date`? (1-based)
+        int occurrence = (date.Day - 1) / 7 + 1;
+
+        if (WeekOfMonth >= 5)
+        {
+            // "Last" occurrence: there is no same weekday 7 days later within this month.
+            return date.AddDays(7).Month != date.Month;
+        }
+
+        return occurrence == WeekOfMonth;
+    }
+}

--- a/CalendarMaker-MAUI/Models/CalendarProject.cs
+++ b/CalendarMaker-MAUI/Models/CalendarProject.cs
@@ -73,6 +73,11 @@ public sealed class CalendarProject
     public Dictionary<int, PhotoLayout> MonthPhotoLayouts { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the user-defined calendar events drawn onto the day cells.
+    /// </summary>
+    public List<CalendarEvent> Events { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the photo layout for the front cover.
     /// </summary>
     public PhotoLayout FrontCoverPhotoLayout { get; set; } = PhotoLayout.Single;

--- a/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
+++ b/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
@@ -58,8 +58,7 @@ internal static class CalendarEventDrawing
             float radius = chipHeight / 3f;
             canvas.DrawRoundRect(chipRect, radius, radius, chipPaint);
 
-            string label = string.IsNullOrWhiteSpace(ev.Emoji) ? ev.Title : $"{ev.Emoji} {ev.Title}";
-            label = label.Trim();
+            string label = ev.Title.Trim();
             if (!string.IsNullOrEmpty(label))
             {
                 textPaint.Color = ContrastingTextColor(color);

--- a/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
+++ b/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
@@ -1,0 +1,108 @@
+using CalendarMaker_MAUI.Models;
+using SkiaSharp;
+
+namespace CalendarMaker_MAUI.Services;
+
+/// <summary>
+/// Shared SkiaSharp drawing routine for rendering event chips inside a day cell. Used by both the
+/// on-screen <see cref="CalendarRenderer"/> and the PDF exporter so the preview matches the export.
+/// </summary>
+internal static class CalendarEventDrawing
+{
+    /// <summary>
+    /// Draws the events occurring on <paramref name="date"/> as small colored chips stacked below the
+    /// day number inside <paramref name="cell"/>. Excess events are summarized with a "+N" chip.
+    /// </summary>
+    /// <param name="canvas">The canvas to draw on.</param>
+    /// <param name="cell">The day cell rectangle.</param>
+    /// <param name="project">The project supplying the event list.</param>
+    /// <param name="date">The date whose events should be drawn.</param>
+    /// <param name="dayNumberHeight">Vertical space reserved at the top of the cell for the day number.</param>
+    public static void DrawDayEvents(SKCanvas canvas, SKRect cell, CalendarProject project, DateTime date, float dayNumberHeight = 14f)
+    {
+        var events = CalendarEventService.GetEventsForDate(project.Events, date);
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        const float horizontalPad = 2f;
+        const float chipGap = 1.5f;
+        float chipHeight = Math.Clamp(cell.Height / 6f, 6f, 11f);
+        float fontSize = Math.Clamp(chipHeight - 3f, 5f, 8f);
+
+        float top = cell.Top + dayNumberHeight;
+        float available = cell.Bottom - top - horizontalPad;
+        if (available < chipHeight)
+        {
+            return; // Cell too short to show chips.
+        }
+
+        int maxChips = Math.Max(1, (int)((available + chipGap) / (chipHeight + chipGap)));
+        bool needsOverflow = events.Count > maxChips;
+        int drawCount = needsOverflow ? Math.Max(1, maxChips - 1) : Math.Min(events.Count, maxChips);
+
+        using var chipPaint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
+        using var textPaint = new SKPaint { TextSize = fontSize, IsAntialias = true };
+
+        float left = cell.Left + horizontalPad;
+        float right = cell.Right - horizontalPad;
+        float y = top;
+
+        for (int i = 0; i < drawCount; i++)
+        {
+            var ev = events[i];
+            var chipRect = new SKRect(left, y, right, y + chipHeight);
+            SKColor color = ParseColor(ev.ColorHex, new SKColor(0x4E, 0x79, 0xA7));
+            chipPaint.Color = color;
+            float radius = chipHeight / 3f;
+            canvas.DrawRoundRect(chipRect, radius, radius, chipPaint);
+
+            string label = string.IsNullOrWhiteSpace(ev.Emoji) ? ev.Title : $"{ev.Emoji} {ev.Title}";
+            label = label.Trim();
+            if (!string.IsNullOrEmpty(label))
+            {
+                textPaint.Color = ContrastingTextColor(color);
+                DrawClippedText(canvas, textPaint, label, chipRect, fontSize);
+            }
+
+            y += chipHeight + chipGap;
+        }
+
+        if (needsOverflow)
+        {
+            int remaining = events.Count - drawCount;
+            var chipRect = new SKRect(left, y, right, y + chipHeight);
+            chipPaint.Color = new SKColor(0x9E, 0x9E, 0x9E);
+            float radius = chipHeight / 3f;
+            canvas.DrawRoundRect(chipRect, radius, radius, chipPaint);
+            textPaint.Color = SKColors.White;
+            DrawClippedText(canvas, textPaint, $"+{remaining}", chipRect, fontSize);
+        }
+    }
+
+    private static void DrawClippedText(SKCanvas canvas, SKPaint textPaint, string text, SKRect chipRect, float fontSize)
+    {
+        canvas.Save();
+        canvas.ClipRect(chipRect);
+        float baseline = chipRect.MidY + fontSize / 2.8f;
+        canvas.DrawText(text, chipRect.Left + 2f, baseline, textPaint);
+        canvas.Restore();
+    }
+
+    private static SKColor ParseColor(string? hex, SKColor fallback)
+    {
+        if (string.IsNullOrWhiteSpace(hex))
+        {
+            return fallback;
+        }
+
+        return SKColor.TryParse(hex, out SKColor parsed) ? parsed : fallback;
+    }
+
+    private static SKColor ContrastingTextColor(SKColor background)
+    {
+        float luminance = (0.299f * background.Red + 0.587f * background.Green + 0.114f * background.Blue) / 255f;
+        return luminance > 0.6f ? SKColors.Black : SKColors.White;
+    }
+}

--- a/CalendarMaker-MAUI/Services/CalendarEventService.cs
+++ b/CalendarMaker-MAUI/Services/CalendarEventService.cs
@@ -1,0 +1,77 @@
+using CalendarMaker_MAUI.Models;
+
+namespace CalendarMaker_MAUI.Services;
+
+/// <summary>
+/// Pure helpers for resolving which <see cref="CalendarEvent"/>s fall on a given date and for
+/// building new events anchored to a clicked date. Kept free of UI/rendering concerns so it can
+/// be unit tested in isolation.
+/// </summary>
+public static class CalendarEventService
+{
+    /// <summary>
+    /// A small, print-friendly palette users can pick event colors from.
+    /// </summary>
+    public static readonly IReadOnlyList<string> Palette = new[]
+    {
+        "#4E79A7", // blue
+        "#E15759", // red
+        "#59A14F", // green
+        "#F28E2B", // orange
+        "#B07AA1", // purple
+        "#EDC948", // yellow
+        "#76B7B2", // teal
+        "#FF9DA7"  // pink
+    };
+
+    /// <summary>
+    /// Returns the events that occur on <paramref name="date"/>, ordered for stable rendering.
+    /// </summary>
+    /// <param name="events">The candidate events (typically <c>project.Events</c>).</param>
+    /// <param name="date">The date to resolve.</param>
+    public static IReadOnlyList<CalendarEvent> GetEventsForDate(IEnumerable<CalendarEvent>? events, DateTime date)
+    {
+        if (events is null)
+        {
+            return Array.Empty<CalendarEvent>();
+        }
+
+        return events
+            .Where(e => e.OccursOn(date))
+            .OrderBy(e => e.Title, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(e => e.Id, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Creates a new event anchored to <paramref name="date"/>, interpreting the anchor according to
+    /// the requested <paramref name="recurrence"/>. All anchor fields are populated from the date so
+    /// switching the recurrence later still resolves correctly.
+    /// </summary>
+    public static CalendarEvent CreateForDate(
+        DateTime date,
+        string title,
+        string? emoji,
+        string colorHex,
+        EventRecurrence recurrence)
+    {
+        return new CalendarEvent
+        {
+            Title = title,
+            Emoji = string.IsNullOrWhiteSpace(emoji) ? null : emoji,
+            ColorHex = colorHex,
+            Recurrence = recurrence,
+            Year = date.Year,
+            Month = date.Month,
+            Day = date.Day,
+            Weekday = date.DayOfWeek,
+            WeekOfMonth = WeekOfMonthFor(date)
+        };
+    }
+
+    /// <summary>
+    /// Returns which occurrence (1-based) of its own weekday the given date is within its month.
+    /// For example, 2025-10-16 (a Thursday) returns 3 because it is the third Thursday of October.
+    /// </summary>
+    public static int WeekOfMonthFor(DateTime date) => (date.Day - 1) / 7 + 1;
+}

--- a/CalendarMaker-MAUI/Services/CalendarEventService.cs
+++ b/CalendarMaker-MAUI/Services/CalendarEventService.cs
@@ -51,14 +51,12 @@ public static class CalendarEventService
     public static CalendarEvent CreateForDate(
         DateTime date,
         string title,
-        string? emoji,
         string colorHex,
         EventRecurrence recurrence)
     {
         return new CalendarEvent
         {
             Title = title,
-            Emoji = string.IsNullOrWhiteSpace(emoji) ? null : emoji,
             ColorHex = colorHex,
             Recurrence = recurrence,
             Year = date.Year,

--- a/CalendarMaker-MAUI/Services/CalendarRenderer.cs
+++ b/CalendarMaker-MAUI/Services/CalendarRenderer.cs
@@ -20,7 +20,7 @@ public sealed class CalendarRenderer : ICalendarRenderer
     }
 
     /// <inheritdoc />
-    public void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month)
+    public void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month, IDictionary<DateTime, SKRect>? dayCellBounds = null)
     {
         var weeks = _calendarEngine.BuildMonthGrid(year, month, project.FirstDayOfWeek);
 
@@ -48,13 +48,13 @@ public sealed class CalendarRenderer : ICalendarRenderer
 
         // Render day grid
         var weeksArea = new SKRect(gridRect.Left, dowRect.Bottom, gridRect.Right, bounds.Bottom);
-        RenderDayGrid(canvas, weeksArea, weeks, month, project);
+        RenderDayGrid(canvas, weeksArea, weeks, month, project, dayCellBounds);
     }
 
     /// <summary>
     /// Renders the calendar grid with an optional background color.
     /// </summary>
-    public void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month, bool applyBackground)
+    public void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month, bool applyBackground, IDictionary<DateTime, SKRect>? dayCellBounds = null)
     {
       SKRect calendarRect = bounds;
    
@@ -86,7 +86,7 @@ Style = SKPaintStyle.Fill
  
    // Draw white/transparent rectangle over the calendar grid area (EXCEPT the header)
    // to "cut out" the background, leaving the header in the colored area
-     RenderCalendarGridWithHeaderInPadding(canvas, calendarRect, project, year, month);
+     RenderCalendarGridWithHeaderInPadding(canvas, calendarRect, project, year, month, dayCellBounds);
             return;
     }
       }
@@ -102,7 +102,7 @@ Style = SKPaintStyle.Fill
      }
 
       // Render the standard calendar grid
-  RenderCalendarGrid(canvas, calendarRect, project, year, month);
+  RenderCalendarGrid(canvas, calendarRect, project, year, month, dayCellBounds);
     }
 
     /// <inheritdoc />
@@ -253,7 +253,7 @@ Style = SKPaintStyle.Fill
         }
     }
 
-    private void RenderDayGrid(SKCanvas canvas, SKRect bounds, List<List<DateTime?>> weeks, int month, CalendarProject project)
+    private void RenderDayGrid(SKCanvas canvas, SKRect bounds, List<List<DateTime?>> weeks, int month, CalendarProject project, IDictionary<DateTime, SKRect>? dayCellBounds = null)
     {
         if (weeks.Count == 0)
         {
@@ -294,6 +294,12 @@ Style = SKPaintStyle.Fill
                 {
                     string dayText = date.Value.Day.ToString(CultureInfo.InvariantCulture);
                     canvas.DrawText(dayText, cellRect.Left + 2, cellRect.Top + textPaint.TextSize + 2, textPaint);
+
+                    CalendarEventDrawing.DrawDayEvents(canvas, cellRect, project, date.Value);
+                    if (dayCellBounds != null)
+                    {
+                        dayCellBounds[date.Value.Date] = cellRect;
+                    }
                 }
             }
         }
@@ -331,7 +337,7 @@ Style = SKPaintStyle.Fill
         }
     }
 
-    private void RenderCalendarGridWithHeaderInPadding(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month)
+    private void RenderCalendarGridWithHeaderInPadding(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month, IDictionary<DateTime, SKRect>? dayCellBounds = null)
     {
         var weeks = _calendarEngine.BuildMonthGrid(year, month, project.FirstDayOfWeek);
 
@@ -370,7 +376,7 @@ Style = SKPaintStyle.Fill
 
         // Render day grid
    var weeksArea = new SKRect(gridRect.Left, dowRect.Bottom, gridRect.Right, bounds.Bottom);
-   RenderDayGrid(canvas, weeksArea, weeks, month, project);
+   RenderDayGrid(canvas, weeksArea, weeks, month, project, dayCellBounds);
     }
 
   private SKColor GetContrastingTextColor(string? backgroundColor)

--- a/CalendarMaker-MAUI/Services/ICalendarRenderer.cs
+++ b/CalendarMaker-MAUI/Services/ICalendarRenderer.cs
@@ -17,7 +17,9 @@ public interface ICalendarRenderer
     /// <param name="project">The calendar project containing theme and settings.</param>
     /// <param name="year">The year to render.</param>
     /// <param name="month">The month to render (1-12).</param>
-    void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month);
+    /// <param name="dayCellBounds">Optional map that, when supplied, is populated with the on-canvas
+    /// rectangle of each in-month day cell (keyed by date) for hit-testing.</param>
+    void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month, IDictionary<DateTime, SKRect>? dayCellBounds = null);
 
     /// <summary>
     /// Renders a complete calendar page including photos and calendar grid with optional background.
@@ -28,7 +30,9 @@ public interface ICalendarRenderer
     /// <param name="year">The year to render.</param>
     /// <param name="month">The month to render (1-12).</param>
     /// <param name="applyBackground">Whether to apply the theme's background color.</param>
-    void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month, bool applyBackground);
+    /// <param name="dayCellBounds">Optional map that, when supplied, is populated with the on-canvas
+    /// rectangle of each in-month day cell (keyed by date) for hit-testing.</param>
+    void RenderCalendarGrid(SKCanvas canvas, SKRect bounds, CalendarProject project, int year, int month, bool applyBackground, IDictionary<DateTime, SKRect>? dayCellBounds = null);
 
     /// <summary>
     /// Renders photos in their designated slots with pan/zoom applied.

--- a/CalendarMaker-MAUI/Services/RenderAndExport.cs
+++ b/CalendarMaker-MAUI/Services/RenderAndExport.cs
@@ -738,6 +738,7 @@ public sealed class PdfExportService : IPdfExportService
         {
        string dayStr = date.Value.Day.ToString(CultureInfo.InvariantCulture);
         canvas.DrawText(dayStr, cell.Left + 2, cell.Top + textPaint.TextSize + 2, textPaint);
+        CalendarEventDrawing.DrawDayEvents(canvas, cell, project, date.Value);
         }
          }
         }
@@ -873,6 +874,7 @@ TextSize = 18,
         {
      string dayStr = date.Value.Day.ToString(CultureInfo.InvariantCulture);
         canvas.DrawText(dayStr, cell.Left + 2, cell.Top + textPaint.TextSize + 2, textPaint);
+        CalendarEventDrawing.DrawDayEvents(canvas, cell, project, date.Value);
         }
       }
      }

--- a/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
+++ b/CalendarMaker-MAUI/ViewModels/DesignerViewModel.cs
@@ -86,6 +86,12 @@ public sealed partial class DesignerViewModel : ObservableObject
     /// </summary>
     public SKRect LastContentRect { get; private set; }
 
+    /// <summary>
+    /// Cached day-cell rectangles for the current month page, keyed by date. Used to hit-test
+    /// taps/clicks so the user can add events to a specific day.
+    /// </summary>
+    public Dictionary<DateTime, SKRect> LastDayCells { get; } = new();
+
     #endregion
 
     #region Gesture State (for touch handling)
@@ -450,6 +456,39 @@ public sealed partial class DesignerViewModel : ObservableObject
         };
 
         modal.Cancelled += async (_, __) =>
+        {
+            await _navigationService.PopModalAsync();
+        };
+
+        await _navigationService.PushModalAsync(modal, true);
+    }
+
+    /// <summary>
+    /// Opens the event editor for the given calendar day, letting the user add, edit, or remove
+    /// events. Persists changes and refreshes the canvas as events are modified.
+    /// </summary>
+    /// <param name="date">The calendar day that was activated (double-clicked or right-clicked).</param>
+    public async Task OpenEventEditorAsync(DateTime date)
+    {
+        if (Project == null)
+        {
+            return;
+        }
+
+        var modal = new Views.EventEditorModal(Project, date);
+
+        modal.EventsChanged += async (_, __) =>
+        {
+            if (Project == null)
+            {
+                return;
+            }
+
+            await _storage.UpdateProjectAsync(Project);
+            OnPropertyChanged(nameof(Project)); // Trigger canvas refresh to show event changes
+        };
+
+        modal.Closed += async (_, __) =>
         {
             await _navigationService.PopModalAsync();
         };

--- a/CalendarMaker-MAUI/Views/DesignerPage.xaml.cs
+++ b/CalendarMaker-MAUI/Views/DesignerPage.xaml.cs
@@ -209,6 +209,9 @@ public partial class DesignerPage : ContentPage
         List<SKRect> photoSlots;
         SKRect photoRect;
 
+        // Day-cell rects are only meaningful on pages that draw a calendar grid; clear stale ones.
+        _viewModel.LastDayCells.Clear();
+
         if (pageIndex == -1) // Front cover
         {
             PhotoLayout layout = project.FrontCoverPhotoLayout;
@@ -246,9 +249,9 @@ public partial class DesignerPage : ContentPage
                 activeSlotIndex);
 
             // Draw calendar for previous year with background if borderless
-            bool applyCalendarBackground = IsMonthPageBorderless(project) && 
+            bool applyCalendarBackground = IsMonthPageBorderless(project) &&
      project.CoverSpec.UseCalendarBackgroundOnBorderless;
-       _calendarRenderer.RenderCalendarGrid(canvas, calRect, project, project.Year - 1, 12, applyCalendarBackground);
+       _calendarRenderer.RenderCalendarGrid(canvas, calRect, project, project.Year - 1, 12, applyCalendarBackground, _viewModel.LastDayCells);
         }
         else if (pageIndex == 12) // Back cover
         {
@@ -291,7 +294,7 @@ public partial class DesignerPage : ContentPage
             // Apply background to calendar area if this is a borderless month page
             bool applyCalendarBackground = IsMonthPageBorderless(project) &&
                                           project.CoverSpec.UseCalendarBackgroundOnBorderless;
-            _calendarRenderer.RenderCalendarGrid(canvas, calRect, project, year, month, applyCalendarBackground);
+            _calendarRenderer.RenderCalendarGrid(canvas, calRect, project, year, month, applyCalendarBackground, _viewModel.LastDayCells);
         }
     }
 
@@ -328,6 +331,18 @@ public partial class DesignerPage : ContentPage
         int pageIndex = _viewModel.PageIndex;
         bool isCover = pageIndex == -1 || pageIndex == 12;
         SKRect hitRect = isCover ? _viewModel.LastContentRect : _viewModel.LastPhotoRect;
+
+        // Right-click a calendar day to add/edit events (desktop). Double-click works everywhere.
+        if (e.ActionType == SKTouchAction.Pressed && e.MouseButton == SKMouseButton.Right)
+        {
+            DateTime? rightClickedDay = HitTestDayCell(pagePt);
+            if (rightClickedDay.HasValue)
+            {
+                OpenEventEditor(rightClickedDay.Value);
+                e.Handled = true;
+                return;
+            }
+        }
 
         switch (e.ActionType)
         {
@@ -435,12 +450,28 @@ public partial class DesignerPage : ContentPage
             return;
         }
 
+        DateTime now = DateTime.UtcNow;
+        bool isDoubleTap = (now - _viewModel.LastTapAt).TotalMilliseconds < 300 &&
+                           SKPoint.Distance(pagePt, _viewModel.LastTapPoint) < 10;
+
+        // A tap on a calendar day cell opens the event editor (double-click to add/edit events).
+        DateTime? day = HitTestDayCell(pagePt);
+        if (day.HasValue)
+        {
+            if (isDoubleTap)
+            {
+                OpenEventEditor(day.Value);
+            }
+
+            _viewModel.LastTapAt = now;
+            _viewModel.LastTapPoint = pagePt;
+            return;
+        }
+
         SKRect targetRect = GetCurrentTargetRect(hitRect);
         if (targetRect.Contains(pagePt))
         {
-            DateTime now = DateTime.UtcNow;
-            if ((now - _viewModel.LastTapAt).TotalMilliseconds < 300 &&
-                SKPoint.Distance(pagePt, _viewModel.LastTapPoint) < 10)
+            if (isDoubleTap)
             {
                 // Execute command on UI thread
                 MainThread.BeginInvokeOnMainThread(async () =>
@@ -455,6 +486,24 @@ public partial class DesignerPage : ContentPage
             _viewModel.LastTapAt = now;
             _viewModel.LastTapPoint = pagePt;
         }
+    }
+
+    private DateTime? HitTestDayCell(SKPoint pt)
+    {
+        foreach (KeyValuePair<DateTime, SKRect> cell in _viewModel.LastDayCells)
+        {
+            if (cell.Value.Contains(pt))
+            {
+                return cell.Key;
+            }
+        }
+
+        return null;
+    }
+
+    private void OpenEventEditor(DateTime date)
+    {
+        MainThread.BeginInvokeOnMainThread(async () => await _viewModel.OpenEventEditorAsync(date));
     }
 
     private int HitTestSlot(SKPoint pt)

--- a/CalendarMaker-MAUI/Views/EventEditorModal.xaml
+++ b/CalendarMaker-MAUI/Views/EventEditorModal.xaml
@@ -24,13 +24,7 @@
                 <Label Text="Add an event" FontAttributes="Bold" />
 
                 <Label Text="Title" />
-                <Entry x:Name="TitleEntry" Placeholder="e.g. Mom's Birthday" />
-
-                <Label Text="Emoji (optional)" />
-                <HorizontalStackLayout Spacing="8">
-                    <Entry x:Name="EmojiEntry" Placeholder="🎂" WidthRequest="70" MaxLength="4" />
-                    <HorizontalStackLayout x:Name="EmojiQuickPicks" Spacing="4" />
-                </HorizontalStackLayout>
+                <Entry x:Name="TitleEntry" Placeholder="e.g. Mom's Birthday 🎂" />
 
                 <Label Text="Color" />
                 <HorizontalStackLayout x:Name="ColorSwatches" Spacing="6" />

--- a/CalendarMaker-MAUI/Views/EventEditorModal.xaml
+++ b/CalendarMaker-MAUI/Views/EventEditorModal.xaml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="CalendarMaker_MAUI.Views.EventEditorModal"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="Events">
+    <ScrollView>
+        <VerticalStackLayout Padding="20" Spacing="16">
+            <Label x:Name="HeaderLabel" FontAttributes="Bold" FontSize="20" />
+
+            <!-- Existing events for this day -->
+            <VerticalStackLayout Spacing="8">
+                <Label Text="Events on this day" FontAttributes="Bold" />
+                <VerticalStackLayout x:Name="ExistingEventsContainer" Spacing="6" />
+                <Label x:Name="NoEventsLabel"
+                       Text="No events yet. Add one below."
+                       FontSize="13"
+                       TextColor="Gray" />
+            </VerticalStackLayout>
+
+            <BoxView HeightRequest="1" Color="LightGray" />
+
+            <!-- Add a new event -->
+            <VerticalStackLayout Spacing="8">
+                <Label Text="Add an event" FontAttributes="Bold" />
+
+                <Label Text="Title" />
+                <Entry x:Name="TitleEntry" Placeholder="e.g. Mom's Birthday" />
+
+                <Label Text="Emoji (optional)" />
+                <HorizontalStackLayout Spacing="8">
+                    <Entry x:Name="EmojiEntry" Placeholder="🎂" WidthRequest="70" MaxLength="4" />
+                    <HorizontalStackLayout x:Name="EmojiQuickPicks" Spacing="4" />
+                </HorizontalStackLayout>
+
+                <Label Text="Color" />
+                <HorizontalStackLayout x:Name="ColorSwatches" Spacing="6" />
+
+                <Label Text="Repeats" />
+                <Picker x:Name="RecurrencePicker" />
+
+                <Button x:Name="AddButton" Text="Add event" />
+            </VerticalStackLayout>
+
+            <BoxView HeightRequest="1" Color="LightGray" />
+
+            <Button x:Name="CloseButton" Text="Done" />
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/CalendarMaker-MAUI/Views/EventEditorModal.xaml.cs
+++ b/CalendarMaker-MAUI/Views/EventEditorModal.xaml.cs
@@ -31,31 +31,12 @@ public partial class EventEditorModal : ContentPage
 
         HeaderLabel.Text = $"Events — {_date.ToString("dddd, MMMM d, yyyy", CultureInfo.InvariantCulture)}";
 
-        BuildEmojiQuickPicks();
         BuildColorSwatches();
         BuildRecurrenceOptions();
         RefreshExistingEvents();
 
         AddButton.Clicked += OnAddClicked;
         CloseButton.Clicked += (_, __) => Closed?.Invoke(this, EventArgs.Empty);
-    }
-
-    private void BuildEmojiQuickPicks()
-    {
-        foreach (string emoji in new[] { "🎂", "🎉", "🏈", "⭐", "❤️", "🎄" })
-        {
-            var btn = new Button
-            {
-                Text = emoji,
-                FontSize = 16,
-                Padding = 0,
-                WidthRequest = 40,
-                HeightRequest = 40,
-                BackgroundColor = Colors.Transparent
-            };
-            btn.Clicked += (_, __) => EmojiEntry.Text = emoji;
-            EmojiQuickPicks.Children.Add(btn);
-        }
     }
 
     private void BuildColorSwatches()
@@ -123,7 +104,6 @@ public partial class EventEditorModal : ContentPage
         var newEvent = CalendarEventService.CreateForDate(
             _date,
             title,
-            EmojiEntry.Text,
             _selectedColor,
             GetSelectedRecurrence());
 
@@ -132,7 +112,6 @@ public partial class EventEditorModal : ContentPage
 
         // Reset the form for the next entry.
         TitleEntry.Text = string.Empty;
-        EmojiEntry.Text = string.Empty;
         RefreshExistingEvents();
     }
 
@@ -160,10 +139,9 @@ public partial class EventEditorModal : ContentPage
             VerticalOptions = LayoutOptions.Center
         };
 
-        string prefix = string.IsNullOrWhiteSpace(ev.Emoji) ? string.Empty : ev.Emoji + " ";
         var label = new Label
         {
-            Text = prefix + ev.Title,
+            Text = ev.Title,
             VerticalOptions = LayoutOptions.Center
         };
 

--- a/CalendarMaker-MAUI/Views/EventEditorModal.xaml.cs
+++ b/CalendarMaker-MAUI/Views/EventEditorModal.xaml.cs
@@ -1,0 +1,229 @@
+using System.Globalization;
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+
+namespace CalendarMaker_MAUI.Views;
+
+/// <summary>
+/// Modal for adding, viewing, and removing <see cref="CalendarEvent"/>s on a specific calendar day.
+/// Mutates the passed project's <see cref="CalendarProject.Events"/> collection directly and raises
+/// <see cref="EventsChanged"/> so the caller can persist and refresh the canvas.
+/// </summary>
+public partial class EventEditorModal : ContentPage
+{
+    private readonly CalendarProject _project;
+    private readonly DateTime _date;
+    private string _selectedColor = CalendarEventService.Palette[0];
+    private readonly List<Button> _swatchButtons = new();
+
+    /// <summary>Raised whenever an event is added or removed.</summary>
+    public event EventHandler? EventsChanged;
+
+    /// <summary>Raised when the user dismisses the modal.</summary>
+    public event EventHandler? Closed;
+
+    public EventEditorModal(CalendarProject project, DateTime date)
+    {
+        InitializeComponent();
+
+        _project = project;
+        _date = date.Date;
+
+        HeaderLabel.Text = $"Events — {_date.ToString("dddd, MMMM d, yyyy", CultureInfo.InvariantCulture)}";
+
+        BuildEmojiQuickPicks();
+        BuildColorSwatches();
+        BuildRecurrenceOptions();
+        RefreshExistingEvents();
+
+        AddButton.Clicked += OnAddClicked;
+        CloseButton.Clicked += (_, __) => Closed?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void BuildEmojiQuickPicks()
+    {
+        foreach (string emoji in new[] { "🎂", "🎉", "🏈", "⭐", "❤️", "🎄" })
+        {
+            var btn = new Button
+            {
+                Text = emoji,
+                FontSize = 16,
+                Padding = 0,
+                WidthRequest = 40,
+                HeightRequest = 40,
+                BackgroundColor = Colors.Transparent
+            };
+            btn.Clicked += (_, __) => EmojiEntry.Text = emoji;
+            EmojiQuickPicks.Children.Add(btn);
+        }
+    }
+
+    private void BuildColorSwatches()
+    {
+        foreach (string hex in CalendarEventService.Palette)
+        {
+            var btn = new Button
+            {
+                WidthRequest = 34,
+                HeightRequest = 34,
+                CornerRadius = 17,
+                BackgroundColor = Color.FromArgb(hex),
+                BorderColor = Colors.Gray,
+                BorderWidth = 1
+            };
+            btn.Clicked += (_, __) => SelectColor(hex);
+            _swatchButtons.Add(btn);
+            ColorSwatches.Children.Add(btn);
+        }
+
+        SelectColor(_selectedColor);
+    }
+
+    private void SelectColor(string hex)
+    {
+        _selectedColor = hex;
+        for (int i = 0; i < _swatchButtons.Count; i++)
+        {
+            bool selected = string.Equals(CalendarEventService.Palette[i], hex, StringComparison.OrdinalIgnoreCase);
+            _swatchButtons[i].BorderColor = selected ? Colors.Black : Colors.Gray;
+            _swatchButtons[i].BorderWidth = selected ? 3 : 1;
+        }
+    }
+
+    private void BuildRecurrenceOptions()
+    {
+        // Order must match the switch in GetSelectedRecurrence.
+        RecurrencePicker.ItemsSource = new List<string>
+        {
+            $"Only on {_date.ToString("MMM d, yyyy", CultureInfo.InvariantCulture)}",
+            $"Every year on {_date.ToString("MMM d", CultureInfo.InvariantCulture)}",
+            $"Every {_date.DayOfWeek}",
+            $"The {OrdinalWeek(_date)} {_date.DayOfWeek} of {_date.ToString("MMMM", CultureInfo.InvariantCulture)}"
+        };
+        RecurrencePicker.SelectedIndex = 0;
+    }
+
+    private EventRecurrence GetSelectedRecurrence() => RecurrencePicker.SelectedIndex switch
+    {
+        1 => EventRecurrence.Annually,
+        2 => EventRecurrence.Weekly,
+        3 => EventRecurrence.MonthlyByWeekday,
+        _ => EventRecurrence.None
+    };
+
+    private void OnAddClicked(object? sender, EventArgs e)
+    {
+        string title = TitleEntry.Text?.Trim() ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            TitleEntry.Focus();
+            return;
+        }
+
+        var newEvent = CalendarEventService.CreateForDate(
+            _date,
+            title,
+            EmojiEntry.Text,
+            _selectedColor,
+            GetSelectedRecurrence());
+
+        _project.Events.Add(newEvent);
+        EventsChanged?.Invoke(this, EventArgs.Empty);
+
+        // Reset the form for the next entry.
+        TitleEntry.Text = string.Empty;
+        EmojiEntry.Text = string.Empty;
+        RefreshExistingEvents();
+    }
+
+    private void RefreshExistingEvents()
+    {
+        ExistingEventsContainer.Children.Clear();
+
+        var events = CalendarEventService.GetEventsForDate(_project.Events, _date);
+        NoEventsLabel.IsVisible = events.Count == 0;
+
+        foreach (var ev in events)
+        {
+            ExistingEventsContainer.Children.Add(BuildEventRow(ev));
+        }
+    }
+
+    private View BuildEventRow(CalendarEvent ev)
+    {
+        var swatch = new BoxView
+        {
+            WidthRequest = 16,
+            HeightRequest = 16,
+            CornerRadius = 8,
+            Color = Color.FromArgb(ev.ColorHex),
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        string prefix = string.IsNullOrWhiteSpace(ev.Emoji) ? string.Empty : ev.Emoji + " ";
+        var label = new Label
+        {
+            Text = prefix + ev.Title,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        var recurrence = new Label
+        {
+            Text = DescribeRecurrence(ev),
+            FontSize = 11,
+            TextColor = Colors.Gray,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        var deleteBtn = new Button
+        {
+            Text = "Delete",
+            FontSize = 12,
+            Padding = new Thickness(8, 2),
+            HorizontalOptions = LayoutOptions.End
+        };
+        deleteBtn.Clicked += (_, __) =>
+        {
+            _project.Events.RemoveAll(x => x.Id == ev.Id);
+            EventsChanged?.Invoke(this, EventArgs.Empty);
+            RefreshExistingEvents();
+        };
+
+        var grid = new Grid
+        {
+            ColumnSpacing = 8,
+            ColumnDefinitions =
+            {
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = GridLength.Star },
+                new ColumnDefinition { Width = GridLength.Auto },
+                new ColumnDefinition { Width = GridLength.Auto }
+            }
+        };
+        grid.Add(swatch, 0, 0);
+        grid.Add(label, 1, 0);
+        grid.Add(recurrence, 2, 0);
+        grid.Add(deleteBtn, 3, 0);
+        return grid;
+    }
+
+    private static string DescribeRecurrence(CalendarEvent ev) => ev.Recurrence switch
+    {
+        EventRecurrence.Annually => "Every year",
+        EventRecurrence.Weekly => $"Every {ev.Weekday}",
+        EventRecurrence.MonthlyByWeekday =>
+            $"{OrdinalWeek(ev.WeekOfMonth)} {ev.Weekday} monthly",
+        _ => "One time"
+    };
+
+    private static string OrdinalWeek(DateTime date) => OrdinalWeek(CalendarEventService.WeekOfMonthFor(date));
+
+    private static string OrdinalWeek(int week) => week switch
+    {
+        1 => "1st",
+        2 => "2nd",
+        3 => "3rd",
+        4 => "4th",
+        _ => "last"
+    };
+}

--- a/CalendarMaker.Tests/Models/CalendarEventRecurrenceEdgeCaseTests.cs
+++ b/CalendarMaker.Tests/Models/CalendarEventRecurrenceEdgeCaseTests.cs
@@ -1,0 +1,89 @@
+using CalendarMaker_MAUI.Models;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Models;
+
+/// <summary>
+/// Additional edge-case coverage for <see cref="CalendarEvent.OccursOn"/> beyond the
+/// happy-path recurrence tests.
+/// </summary>
+public class CalendarEventRecurrenceEdgeCaseTests
+{
+    [Fact]
+    public void Annually_LeapDay_MatchesOnlyInLeapYears()
+    {
+        var leapBirthday = new CalendarEvent { Recurrence = EventRecurrence.Annually, Month = 2, Day = 29 };
+
+        leapBirthday.OccursOn(new DateTime(2024, 2, 29)).Should().BeTrue();  // leap year
+        leapBirthday.OccursOn(new DateTime(2025, 2, 28)).Should().BeFalse(); // non-leap, no Feb 29
+        leapBirthday.OccursOn(new DateTime(2028, 2, 29)).Should().BeTrue();  // next leap year
+    }
+
+    [Fact]
+    public void Weekly_MatchesAcrossMonthAndYearBoundaries()
+    {
+        var ev = new CalendarEvent { Recurrence = EventRecurrence.Weekly, Weekday = DayOfWeek.Wednesday };
+
+        ev.OccursOn(new DateTime(2025, 12, 31)).Should().BeTrue(); // Wednesday
+        ev.OccursOn(new DateTime(2026, 1, 7)).Should().BeTrue();   // Wednesday, next year
+        ev.OccursOn(new DateTime(2026, 1, 8)).Should().BeFalse();  // Thursday
+    }
+
+    [Fact]
+    public void MonthlyByWeekday_FirstOccurrence_MatchesFirstWeekdayOfMonth()
+    {
+        // First Monday of September (US Labor Day).
+        var laborDay = new CalendarEvent
+        {
+            Recurrence = EventRecurrence.MonthlyByWeekday,
+            Month = 9,
+            Weekday = DayOfWeek.Monday,
+            WeekOfMonth = 1
+        };
+
+        laborDay.OccursOn(new DateTime(2025, 9, 1)).Should().BeTrue();  // 1st Monday 2025
+        laborDay.OccursOn(new DateTime(2025, 9, 8)).Should().BeFalse(); // 2nd Monday
+        laborDay.OccursOn(new DateTime(2026, 9, 7)).Should().BeTrue();  // 1st Monday 2026
+    }
+
+    [Fact]
+    public void MonthlyByWeekday_FourthAndLast_DistinguishedWhenMonthHasFiveWeekdays()
+    {
+        // October 2025 has five Fridays (3, 10, 17, 24, 31).
+        var fourthFriday = new CalendarEvent
+        {
+            Recurrence = EventRecurrence.MonthlyByWeekday,
+            Month = 10,
+            Weekday = DayOfWeek.Friday,
+            WeekOfMonth = 4
+        };
+        var lastFriday = new CalendarEvent
+        {
+            Recurrence = EventRecurrence.MonthlyByWeekday,
+            Month = 10,
+            Weekday = DayOfWeek.Friday,
+            WeekOfMonth = 5 // "last"
+        };
+
+        fourthFriday.OccursOn(new DateTime(2025, 10, 24)).Should().BeTrue();
+        fourthFriday.OccursOn(new DateTime(2025, 10, 31)).Should().BeFalse();
+
+        lastFriday.OccursOn(new DateTime(2025, 10, 31)).Should().BeTrue();
+        lastFriday.OccursOn(new DateTime(2025, 10, 24)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void MonthlyByWeekday_WrongMonth_DoesNotMatch()
+    {
+        var ev = new CalendarEvent
+        {
+            Recurrence = EventRecurrence.MonthlyByWeekday,
+            Month = 11,
+            Weekday = DayOfWeek.Thursday,
+            WeekOfMonth = 4
+        };
+
+        // 4th Thursday exists in other months too, but the rule is pinned to November.
+        ev.OccursOn(new DateTime(2025, 10, 23)).Should().BeFalse();
+    }
+}

--- a/CalendarMaker.Tests/Models/CalendarEventTests.cs
+++ b/CalendarMaker.Tests/Models/CalendarEventTests.cs
@@ -1,0 +1,75 @@
+using CalendarMaker_MAUI.Models;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Models;
+
+/// <summary>
+/// Tests for <see cref="CalendarEvent.OccursOn"/> across every recurrence rule.
+/// </summary>
+public class CalendarEventTests
+{
+    [Fact]
+    public void None_MatchesOnlyTheExactDate()
+    {
+        var ev = new CalendarEvent { Recurrence = EventRecurrence.None, Year = 2025, Month = 7, Day = 4 };
+
+        ev.OccursOn(new DateTime(2025, 7, 4)).Should().BeTrue();
+        ev.OccursOn(new DateTime(2026, 7, 4)).Should().BeFalse(); // different year
+        ev.OccursOn(new DateTime(2025, 7, 5)).Should().BeFalse(); // different day
+    }
+
+    [Fact]
+    public void Annually_MatchesSameMonthAndDayEveryYear()
+    {
+        var birthday = new CalendarEvent { Recurrence = EventRecurrence.Annually, Month = 3, Day = 15 };
+
+        birthday.OccursOn(new DateTime(2025, 3, 15)).Should().BeTrue();
+        birthday.OccursOn(new DateTime(2031, 3, 15)).Should().BeTrue();
+        birthday.OccursOn(new DateTime(2025, 3, 16)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Weekly_MatchesEveryOccurrenceOfTheWeekday()
+    {
+        var ev = new CalendarEvent { Recurrence = EventRecurrence.Weekly, Weekday = DayOfWeek.Monday };
+
+        ev.OccursOn(new DateTime(2025, 6, 2)).Should().BeTrue();  // Monday
+        ev.OccursOn(new DateTime(2025, 6, 9)).Should().BeTrue();  // next Monday
+        ev.OccursOn(new DateTime(2025, 6, 3)).Should().BeFalse(); // Tuesday
+    }
+
+    [Fact]
+    public void MonthlyByWeekday_MatchesNthWeekdayAcrossYears()
+    {
+        // Third Thursday of October (moves with the year).
+        var ev = new CalendarEvent
+        {
+            Recurrence = EventRecurrence.MonthlyByWeekday,
+            Month = 10,
+            Weekday = DayOfWeek.Thursday,
+            WeekOfMonth = 3
+        };
+
+        ev.OccursOn(new DateTime(2025, 10, 16)).Should().BeTrue();  // 3rd Thursday 2025
+        ev.OccursOn(new DateTime(2026, 10, 15)).Should().BeTrue();  // 3rd Thursday 2026
+        ev.OccursOn(new DateTime(2026, 10, 16)).Should().BeFalse(); // Friday
+        ev.OccursOn(new DateTime(2025, 10, 9)).Should().BeFalse();  // 2nd Thursday
+        ev.OccursOn(new DateTime(2025, 11, 20)).Should().BeFalse(); // right weekday/occurrence, wrong month
+    }
+
+    [Fact]
+    public void MonthlyByWeekday_LastOccurrence_MatchesFinalWeekdayOfMonth()
+    {
+        // Last Monday of May (e.g. Memorial Day). WeekOfMonth 5 means "last".
+        var ev = new CalendarEvent
+        {
+            Recurrence = EventRecurrence.MonthlyByWeekday,
+            Month = 5,
+            Weekday = DayOfWeek.Monday,
+            WeekOfMonth = 5
+        };
+
+        ev.OccursOn(new DateTime(2025, 5, 26)).Should().BeTrue();  // last Monday 2025
+        ev.OccursOn(new DateTime(2025, 5, 19)).Should().BeFalse(); // an earlier Monday
+    }
+}

--- a/CalendarMaker.Tests/Models/CalendarProjectEventsSerializationTests.cs
+++ b/CalendarMaker.Tests/Models/CalendarProjectEventsSerializationTests.cs
@@ -17,8 +17,7 @@ public class CalendarProjectEventsSerializationTests
         project.Events.Add(new CalendarEvent
         {
             Id = "e1",
-            Title = "Mom's Birthday",
-            Emoji = "🎂",
+            Title = "Mom's Birthday 🎂",
             ColorHex = "#E15759",
             Recurrence = EventRecurrence.Annually,
             Month = 4,
@@ -27,8 +26,7 @@ public class CalendarProjectEventsSerializationTests
         project.Events.Add(new CalendarEvent
         {
             Id = "e2",
-            Title = "Thanksgiving",
-            Emoji = "🦃",
+            Title = "Thanksgiving 🦃",
             ColorHex = "#F28E2B",
             Recurrence = EventRecurrence.MonthlyByWeekday,
             Month = 11,

--- a/CalendarMaker.Tests/Models/CalendarProjectEventsSerializationTests.cs
+++ b/CalendarMaker.Tests/Models/CalendarProjectEventsSerializationTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using CalendarMaker_MAUI.Models;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Models;
+
+/// <summary>
+/// Events are persisted as part of the project's JSON (see ProjectStorageService). These tests
+/// lock in that they round-trip correctly and that projects saved before events existed still load.
+/// </summary>
+public class CalendarProjectEventsSerializationTests
+{
+    [Fact]
+    public void Events_RoundTripThroughJson_PreserveAllFields()
+    {
+        var project = new CalendarProject { Id = "p1", Name = "Test", Year = 2025 };
+        project.Events.Add(new CalendarEvent
+        {
+            Id = "e1",
+            Title = "Mom's Birthday",
+            Emoji = "🎂",
+            ColorHex = "#E15759",
+            Recurrence = EventRecurrence.Annually,
+            Month = 4,
+            Day = 12
+        });
+        project.Events.Add(new CalendarEvent
+        {
+            Id = "e2",
+            Title = "Thanksgiving",
+            Emoji = "🦃",
+            ColorHex = "#F28E2B",
+            Recurrence = EventRecurrence.MonthlyByWeekday,
+            Month = 11,
+            Weekday = DayOfWeek.Thursday,
+            WeekOfMonth = 4
+        });
+
+        string json = JsonSerializer.Serialize(project);
+        var restored = JsonSerializer.Deserialize<CalendarProject>(json);
+
+        restored.Should().NotBeNull();
+        restored!.Events.Should().HaveCount(2);
+        restored.Events.Should().BeEquivalentTo(project.Events);
+    }
+
+    [Fact]
+    public void Deserialize_ProjectJsonWithoutEvents_YieldsEmptyEventList()
+    {
+        // A project saved before the Events field existed has no "Events" property.
+        const string legacyJson = """{ "Id": "old", "Name": "Legacy", "Year": 2024 }""";
+
+        var restored = JsonSerializer.Deserialize<CalendarProject>(legacyJson);
+
+        restored.Should().NotBeNull();
+        restored!.Events.Should().NotBeNull().And.BeEmpty();
+    }
+
+    [Fact]
+    public void Recurrence_SerializesAsInteger_AndSurvivesRoundTrip()
+    {
+        var ev = new CalendarEvent { Recurrence = EventRecurrence.Weekly, Weekday = DayOfWeek.Friday };
+
+        string json = JsonSerializer.Serialize(ev);
+        var restored = JsonSerializer.Deserialize<CalendarEvent>(json);
+
+        restored!.Recurrence.Should().Be(EventRecurrence.Weekly);
+        restored.Weekday.Should().Be(DayOfWeek.Friday);
+    }
+}

--- a/CalendarMaker.Tests/Services/CalendarEventServiceTests.cs
+++ b/CalendarMaker.Tests/Services/CalendarEventServiceTests.cs
@@ -61,10 +61,9 @@ public class CalendarEventServiceTests
     {
         var date = new DateTime(2025, 10, 16); // a Thursday, 3rd of the month
 
-        var ev = CalendarEventService.CreateForDate(date, "Book club", "📚", "#59A14F", EventRecurrence.MonthlyByWeekday);
+        var ev = CalendarEventService.CreateForDate(date, "Book club", "#59A14F", EventRecurrence.MonthlyByWeekday);
 
         ev.Title.Should().Be("Book club");
-        ev.Emoji.Should().Be("📚");
         ev.ColorHex.Should().Be("#59A14F");
         ev.Recurrence.Should().Be(EventRecurrence.MonthlyByWeekday);
         ev.Year.Should().Be(2025);
@@ -75,14 +74,6 @@ public class CalendarEventServiceTests
 
         // The created event should resolve to its own anchor date.
         ev.OccursOn(date).Should().BeTrue();
-    }
-
-    [Fact]
-    public void CreateForDate_BlankEmoji_StoredAsNull()
-    {
-        var ev = CalendarEventService.CreateForDate(new DateTime(2025, 1, 1), "New Year", "   ", "#4E79A7", EventRecurrence.Annually);
-
-        ev.Emoji.Should().BeNull();
     }
 
     [Fact]

--- a/CalendarMaker.Tests/Services/CalendarEventServiceTests.cs
+++ b/CalendarMaker.Tests/Services/CalendarEventServiceTests.cs
@@ -1,0 +1,94 @@
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="CalendarEventService"/> resolution and event-building helpers.
+/// </summary>
+public class CalendarEventServiceTests
+{
+    [Fact]
+    public void GetEventsForDate_ReturnsOnlyMatchingEvents()
+    {
+        var events = new List<CalendarEvent>
+        {
+            new() { Title = "July 4th", Recurrence = EventRecurrence.Annually, Month = 7, Day = 4 },
+            new() { Title = "Payday", Recurrence = EventRecurrence.Weekly, Weekday = DayOfWeek.Friday },
+            new() { Title = "One-off", Recurrence = EventRecurrence.None, Year = 2025, Month = 7, Day = 4 }
+        };
+
+        // 2025-07-04 is a Friday, so all three match.
+        var onJuly4 = CalendarEventService.GetEventsForDate(events, new DateTime(2025, 7, 4));
+        onJuly4.Should().HaveCount(3);
+
+        // 2025-07-11 is a Friday but not July 4th, so only the weekly event matches.
+        var onJuly11 = CalendarEventService.GetEventsForDate(events, new DateTime(2025, 7, 11));
+        onJuly11.Select(e => e.Title).Should().ContainSingle().Which.Should().Be("Payday");
+    }
+
+    [Fact]
+    public void GetEventsForDate_OrdersByTitle()
+    {
+        var events = new List<CalendarEvent>
+        {
+            new() { Title = "Zebra", Recurrence = EventRecurrence.Annually, Month = 1, Day = 1 },
+            new() { Title = "Apple", Recurrence = EventRecurrence.Annually, Month = 1, Day = 1 }
+        };
+
+        var result = CalendarEventService.GetEventsForDate(events, new DateTime(2025, 1, 1));
+
+        result.Select(e => e.Title).Should().ContainInOrder("Apple", "Zebra");
+    }
+
+    [Fact]
+    public void GetEventsForDate_NullSource_ReturnsEmpty()
+    {
+        CalendarEventService.GetEventsForDate(null, new DateTime(2025, 1, 1)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WeekOfMonthFor_ReturnsCorrectOccurrence()
+    {
+        CalendarEventService.WeekOfMonthFor(new DateTime(2025, 10, 16)).Should().Be(3); // 3rd Thursday
+        CalendarEventService.WeekOfMonthFor(new DateTime(2025, 10, 1)).Should().Be(1);
+        CalendarEventService.WeekOfMonthFor(new DateTime(2025, 10, 8)).Should().Be(2);
+    }
+
+    [Fact]
+    public void CreateForDate_PopulatesAnchorFieldsFromDate()
+    {
+        var date = new DateTime(2025, 10, 16); // a Thursday, 3rd of the month
+
+        var ev = CalendarEventService.CreateForDate(date, "Book club", "📚", "#59A14F", EventRecurrence.MonthlyByWeekday);
+
+        ev.Title.Should().Be("Book club");
+        ev.Emoji.Should().Be("📚");
+        ev.ColorHex.Should().Be("#59A14F");
+        ev.Recurrence.Should().Be(EventRecurrence.MonthlyByWeekday);
+        ev.Year.Should().Be(2025);
+        ev.Month.Should().Be(10);
+        ev.Day.Should().Be(16);
+        ev.Weekday.Should().Be(DayOfWeek.Thursday);
+        ev.WeekOfMonth.Should().Be(3);
+
+        // The created event should resolve to its own anchor date.
+        ev.OccursOn(date).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateForDate_BlankEmoji_StoredAsNull()
+    {
+        var ev = CalendarEventService.CreateForDate(new DateTime(2025, 1, 1), "New Year", "   ", "#4E79A7", EventRecurrence.Annually);
+
+        ev.Emoji.Should().BeNull();
+    }
+
+    [Fact]
+    public void Palette_IsNonEmpty()
+    {
+        CalendarEventService.Palette.Should().NotBeEmpty();
+        CalendarEventService.Palette.Should().OnlyContain(c => c.StartsWith("#"));
+    }
+}

--- a/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
+++ b/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
@@ -1,0 +1,104 @@
+using CalendarMaker_MAUI.Models;
+using CalendarMaker_MAUI.Services;
+using FluentAssertions;
+using Moq;
+using SkiaSharp;
+
+namespace CalendarMaker.Tests.Services;
+
+/// <summary>
+/// Verifies that <see cref="CalendarRenderer"/> reports the day-cell rectangles used to hit-test
+/// clicks for the calendar-events feature, and that rendering events does not throw.
+/// </summary>
+public class CalendarRendererDayCellsTests
+{
+    private static CalendarRenderer CreateRenderer() =>
+        new(new CalendarEngine(), Mock.Of<IImageProcessor>());
+
+    private static (SKBitmap bmp, SKCanvas canvas) CreateCanvas()
+    {
+        var bmp = new SKBitmap(600, 600);
+        return (bmp, new SKCanvas(bmp));
+    }
+
+    [Fact]
+    public void RenderCalendarGrid_PopulatesOneRectPerDayOfMonth()
+    {
+        var renderer = CreateRenderer();
+        var project = new CalendarProject { FirstDayOfWeek = DayOfWeek.Sunday };
+        var cells = new Dictionary<DateTime, SKRect>();
+        var (bmp, canvas) = CreateCanvas();
+
+        using (bmp)
+        using (canvas)
+        {
+            renderer.RenderCalendarGrid(canvas, new SKRect(0, 0, 600, 500), project, 2025, 1, cells);
+        }
+
+        cells.Should().HaveCount(31); // January has 31 days
+        cells.Keys.Should().Contain(new DateTime(2025, 1, 1));
+        cells.Keys.Should().Contain(new DateTime(2025, 1, 31));
+        cells.Values.Should().OnlyContain(r => r.Width > 0 && r.Height > 0);
+    }
+
+    [Fact]
+    public void RenderCalendarGrid_DayCellRectsStayWithinBounds()
+    {
+        var renderer = CreateRenderer();
+        var project = new CalendarProject { FirstDayOfWeek = DayOfWeek.Monday };
+        var cells = new Dictionary<DateTime, SKRect>();
+        var bounds = new SKRect(10, 20, 590, 480);
+        var (bmp, canvas) = CreateCanvas();
+
+        using (bmp)
+        using (canvas)
+        {
+            renderer.RenderCalendarGrid(canvas, bounds, project, 2025, 2, cells);
+        }
+
+        cells.Should().HaveCount(28); // February 2025 (non-leap)
+        cells.Values.Should().OnlyContain(r =>
+            r.Left >= bounds.Left - 0.5f &&
+            r.Right <= bounds.Right + 0.5f &&
+            r.Bottom <= bounds.Bottom + 0.5f);
+    }
+
+    [Fact]
+    public void RenderCalendarGrid_WithEvents_DoesNotThrow()
+    {
+        var renderer = CreateRenderer();
+        var project = new CalendarProject { FirstDayOfWeek = DayOfWeek.Sunday };
+        project.Events.Add(new CalendarEvent
+        {
+            Title = "Holiday",
+            Emoji = "🎉",
+            ColorHex = "#59A14F",
+            Recurrence = EventRecurrence.Annually,
+            Month = 1,
+            Day = 1
+        });
+        var (bmp, canvas) = CreateCanvas();
+
+        using (bmp)
+        using (canvas)
+        {
+            var act = () => renderer.RenderCalendarGrid(canvas, new SKRect(0, 0, 600, 500), project, 2025, 1);
+            act.Should().NotThrow();
+        }
+    }
+
+    [Fact]
+    public void RenderCalendarGrid_NullDayCellBounds_IsAllowed()
+    {
+        var renderer = CreateRenderer();
+        var project = new CalendarProject { FirstDayOfWeek = DayOfWeek.Sunday };
+        var (bmp, canvas) = CreateCanvas();
+
+        using (bmp)
+        using (canvas)
+        {
+            var act = () => renderer.RenderCalendarGrid(canvas, new SKRect(0, 0, 600, 500), project, 2025, 3, dayCellBounds: null);
+            act.Should().NotThrow();
+        }
+    }
+}

--- a/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
+++ b/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
@@ -70,8 +70,7 @@ public class CalendarRendererDayCellsTests
         var project = new CalendarProject { FirstDayOfWeek = DayOfWeek.Sunday };
         project.Events.Add(new CalendarEvent
         {
-            Title = "Holiday",
-            Emoji = "🎉",
+            Title = "Holiday 🎉",
             ColorHex = "#59A14F",
             Recurrence = EventRecurrence.Annually,
             Month = 1,


### PR DESCRIPTION
Closes #29

Adds user-defined **calendar events** that render onto the day cells of the calendar.

## How you use it
- On a month page, **double-click** a day (works on every platform) or **right-click** it (desktop) to open the new **Event Editor**.
- The editor lists that day's events and lets you add one with:
  - a **title** (type an emoji directly into the title if you want one, e.g. "Mom's Birthday 🎂")
  - a **color** from a print-friendly swatch palette
  - a **repetition** option contextual to the clicked date

Events show up as small colored chips inside the day cell, in both the live preview and the exported PDF.

## Requirements from the issue
| Requirement | Implementation |
| --- | --- |
| Colors to distinguish events | Per-event accent color chosen from a curated palette; drawn as a colored chip with contrast-aware text |
| Emoji / logo for importance | Emojis can be typed directly into the event title (no separate field needed) and render in the chip |
| Repetition (annual, Nth weekday, etc.) | `EventRecurrence`: **None** (single date), **Annually** (same month/day — birthdays), **Weekly** (a weekday), **MonthlyByWeekday** (e.g. "3rd Thursday of October" / "last Monday of May") — the weekday rules keep holidays correct as the calendar year changes |

## Architecture
- **`CalendarEvent`** model + `OccursOn(date)` resolution; **`CalendarProject.Events`** persists through the existing project JSON (field appended, so old projects load unchanged).
- **`CalendarEventService`** — pure, unit-tested resolution + event-building helpers and the color palette.
- **`CalendarEventDrawing`** — one shared SkiaSharp routine used by both `CalendarRenderer` (preview) and `RenderAndExport` (PDF), so preview and export stay identical.
- The renderer now optionally reports each day cell's rectangle; `DesignerPage` uses that map to hit-test clicks, and `DesignerViewModel.OpenEventEditorAsync` shows the modal and persists/refreshes on change.

## Testing
- `dotnet build` (all target frameworks): **0 errors**.
- `dotnet test`: **passing**, including tests covering every recurrence rule (incl. Nth-weekday and "last" weekday), JSON round-trip/back-compat, and the renderer's day-cell hit-test map.
- The click-to-open gesture wiring was validated via compilation (driving the MAUI desktop UI isn't automatable in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)