### PR TITLE
Add unit tests for the 12x12 square page size

### DIFF
--- a/CalendarMaker.Tests/Models/PageSize12x12Tests.cs
+++ b/CalendarMaker.Tests/Models/PageSize12x12Tests.cs
@@ -1,0 +1,70 @@
+using CalendarMaker_MAUI.Models;
+using FluentAssertions;
+
+namespace CalendarMaker.Tests.Models;
+
+/// <summary>
+/// Tests covering the 12x12 square page size (issue #54).
+/// </summary>
+public class PageSize12x12Tests
+{
+    [Fact]
+    public void GetInches_Square12x12_ReturnsTwelveByTwelve()
+    {
+        var (w, h) = PageSizes.GetInches(PageSize.Square_12x12);
+
+        w.Should().Be(12.0);
+        h.Should().Be(12.0);
+    }
+
+    [Fact]
+    public void GetPoints_Square12x12_Portrait_Returns864Points()
+    {
+        var spec = new PageSpec { Size = PageSize.Square_12x12, Orientation = PageOrientation.Portrait };
+
+        var (w, h) = PageSizes.GetPoints(spec);
+
+        w.Should().BeApproximately(12.0 * 72.0, 0.001); // 864
+        h.Should().BeApproximately(12.0 * 72.0, 0.001); // 864
+    }
+
+    [Fact]
+    public void GetPoints_Square12x12_IsSquareRegardlessOfOrientation()
+    {
+        var portrait = new PageSpec { Size = PageSize.Square_12x12, Orientation = PageOrientation.Portrait };
+        var landscape = new PageSpec { Size = PageSize.Square_12x12, Orientation = PageOrientation.Landscape };
+
+        var (pw, ph) = PageSizes.GetPoints(portrait);
+        var (lw, lh) = PageSizes.GetPoints(landscape);
+
+        // A square page has identical dimensions, so swapping for landscape is a no-op.
+        pw.Should().Be(ph);
+        lw.Should().Be(pw);
+        lh.Should().Be(ph);
+    }
+
+    [Fact]
+    public void PageSizeDisplay_Square12x12_Returns12x12()
+    {
+        var project = new CalendarProject
+        {
+            PageSpec = new PageSpec { Size = PageSize.Square_12x12 }
+        };
+
+        project.PageSizeDisplay.Should().Be("12x12");
+    }
+
+    [Fact]
+    public void Square12x12_IsDeclaredLast_SoExistingEnumValuesAreUnchanged()
+    {
+        // Saved projects serialize the enum as an integer, so the pre-existing members must keep
+        // their original values and the new one must sort after Custom.
+        ((int)PageSize.FiveBySeven).Should().Be(0);
+        ((int)PageSize.A4).Should().Be(1);
+        ((int)PageSize.Letter).Should().Be(2);
+        ((int)PageSize.Tabloid_11x17).Should().Be(3);
+        ((int)PageSize.SuperB_13x19).Should().Be(4);
+        ((int)PageSize.Custom).Should().Be(5);
+        ((int)PageSize.Square_12x12).Should().BeGreaterThan((int)PageSize.Custom);
+    }
+}


### PR DESCRIPTION
Follow-up to #54 / #62.

The 12x12 square page size was merged in #62, but its unit tests were pushed to that branch **after** the PR had already been merged and closed, so they never landed on `main`. This PR adds them.

## Tests (`PageSize12x12Tests`)
- `GetInches(Square_12x12)` returns 12×12
- `GetPoints(Square_12x12)` returns 864pt, and is identical in portrait/landscape (square → orientation swap is a no-op)
- `PageSizeDisplay` returns `"12x12"`
- A guard asserting `Square_12x12` is declared last so the integer enum values of the pre-existing sizes (and thus existing saved `project.json` files) are unaffected

## Testing
- `dotnet test`: **35/35 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)