### PR TITLE
Word-wrap long event titles within their day

### DIFF
--- a/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
+++ b/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System.Text;
 using CalendarMaker_MAUI.Models;
 using SkiaSharp;
 
@@ -13,6 +13,10 @@ internal static class CalendarEventDrawing
     private static readonly SKColor DefaultChipColor = new(0x4E, 0x79, 0xA7);
     private static readonly SKColor OverflowChipColor = new(0x9E, 0x9E, 0x9E);
 
+    // Platform emoji-capable typeface (e.g. Segoe UI Emoji on Windows) resolved by matching a
+    // known emoji code point. Used as a fallback for glyphs the default typeface cannot render.
+    private static readonly SKTypeface? EmojiTypeface = SKFontManager.Default.MatchCharacter(0x1F600);
+
     private const float OuterPad = 2f;
     private const float ChipGap = 1.5f;
     private const float TextPadX = 3f;
@@ -21,7 +25,8 @@ internal static class CalendarEventDrawing
     /// <summary>
     /// Draws the events occurring on <paramref name="date"/> as colored chips stacked below the day
     /// number inside <paramref name="cell"/>. Long titles word-wrap onto multiple lines within the
-    /// cell width; events that do not fit are summarized with a "+N more" chip.
+    /// cell width; events that do not fit are summarized with a "+N more" chip. Emoji in titles are
+    /// rendered via an emoji-capable fallback font.
     /// </summary>
     /// <param name="canvas">The canvas to draw on.</param>
     /// <param name="cell">The day cell rectangle.</param>
@@ -54,7 +59,9 @@ internal static class CalendarEventDrawing
         }
 
         using var chipPaint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
-        using var textPaint = new SKPaint { TextSize = fontSize, IsAntialias = true };
+        using var textPaint = new SKPaint { IsAntialias = true };
+        using var baseFont = new SKFont(SKTypeface.Default, fontSize) { Edging = SKFontEdging.SubpixelAntialias };
+        using var emojiFont = EmojiTypeface is null ? null : new SKFont(EmojiTypeface, fontSize) { Edging = SKFontEdging.SubpixelAntialias };
 
         // Lay out as many event chips as fit, each wrapped to the cell width.
         var chips = new List<(List<string> Lines, SKColor Color)>();
@@ -62,7 +69,7 @@ internal static class CalendarEventDrawing
         int placed = 0;
         for (; placed < events.Count; placed++)
         {
-            var lines = WrapText(textPaint, events[placed].Title.Trim(), innerWidth);
+            var lines = WrapText(events[placed].Title.Trim(), innerWidth, baseFont, emojiFont, textPaint);
             if (lines.Count == 0)
             {
                 lines.Add(string.Empty);
@@ -83,7 +90,7 @@ internal static class CalendarEventDrawing
         if (chips.Count == 0)
         {
             int maxLines = Math.Max(1, (int)((availableHeight - 2f * TextPadY) / lineHeight));
-            var lines = TruncateToLines(textPaint, WrapText(textPaint, events[0].Title.Trim(), innerWidth), maxLines, innerWidth);
+            var lines = TruncateToLines(WrapText(events[0].Title.Trim(), innerWidth, baseFont, emojiFont, textPaint), maxLines, innerWidth, baseFont, emojiFont, textPaint);
             chips.Add((lines, ParseColor(events[0].ColorHex, DefaultChipColor)));
             usedHeight = lines.Count * lineHeight + 2f * TextPadY;
             placed = 1;
@@ -110,7 +117,7 @@ internal static class CalendarEventDrawing
         {
             float chipHeight = lines.Count * lineHeight + 2f * TextPadY;
             var chipRect = new SKRect(left, y, right, y + chipHeight);
-            DrawChip(canvas, chipPaint, textPaint, chipRect, lines, color, lineHeight, fontSize);
+            DrawChip(canvas, chipPaint, textPaint, baseFont, emojiFont, chipRect, lines, color, lineHeight, fontSize);
             y = chipRect.Bottom + ChipGap;
         }
 
@@ -118,11 +125,11 @@ internal static class CalendarEventDrawing
         if (leftover > 0 && y + singleChipHeight <= bottom + 0.5f)
         {
             var chipRect = new SKRect(left, y, right, y + singleChipHeight);
-            DrawChip(canvas, chipPaint, textPaint, chipRect, new List<string> { $"+{leftover} more" }, OverflowChipColor, lineHeight, fontSize);
+            DrawChip(canvas, chipPaint, textPaint, baseFont, emojiFont, chipRect, new List<string> { $"+{leftover} more" }, OverflowChipColor, lineHeight, fontSize);
         }
     }
 
-    private static void DrawChip(SKCanvas canvas, SKPaint chipPaint, SKPaint textPaint, SKRect chipRect, List<string> lines, SKColor color, float lineHeight, float fontSize)
+    private static void DrawChip(SKCanvas canvas, SKPaint chipPaint, SKPaint textPaint, SKFont baseFont, SKFont? emojiFont, SKRect chipRect, List<string> lines, SKColor color, float lineHeight, float fontSize)
     {
         chipPaint.Color = color;
         float radius = Math.Min(4f, chipRect.Height / 3f);
@@ -134,7 +141,7 @@ internal static class CalendarEventDrawing
         float baseline = chipRect.Top + TextPadY + fontSize;
         foreach (string line in lines)
         {
-            canvas.DrawText(line, chipRect.Left + TextPadX, baseline, textPaint);
+            DrawText(canvas, line, chipRect.Left + TextPadX, baseline, baseFont, emojiFont, textPaint);
             baseline += lineHeight;
         }
         canvas.Restore();
@@ -144,7 +151,7 @@ internal static class CalendarEventDrawing
     /// Splits <paramref name="text"/> into lines that each fit within <paramref name="maxWidth"/>,
     /// breaking on spaces and hard-breaking any single word that is wider than the line.
     /// </summary>
-    private static List<string> WrapText(SKPaint paint, string text, float maxWidth)
+    private static List<string> WrapText(string text, float maxWidth, SKFont baseFont, SKFont? emojiFont, SKPaint paint)
     {
         var lines = new List<string>();
         if (string.IsNullOrWhiteSpace(text))
@@ -157,7 +164,7 @@ internal static class CalendarEventDrawing
             if (lines.Count > 0)
             {
                 string candidate = lines[^1] + " " + word;
-                if (paint.MeasureText(candidate) <= maxWidth)
+                if (MeasureText(candidate, baseFont, emojiFont, paint) <= maxWidth)
                 {
                     lines[^1] = candidate;
                     continue;
@@ -165,9 +172,9 @@ internal static class CalendarEventDrawing
             }
 
             string remaining = word;
-            while (paint.MeasureText(remaining) > maxWidth && remaining.Length > 1)
+            while (MeasureText(remaining, baseFont, emojiFont, paint) > maxWidth && remaining.Length > 1)
             {
-                int fit = MaxCharsThatFit(paint, remaining, maxWidth);
+                int fit = MaxCharsThatFit(remaining, maxWidth, baseFont, emojiFont, paint);
                 lines.Add(remaining.Substring(0, fit));
                 remaining = remaining.Substring(fit);
             }
@@ -178,7 +185,7 @@ internal static class CalendarEventDrawing
         return lines;
     }
 
-    private static List<string> TruncateToLines(SKPaint paint, List<string> lines, int maxLines, float maxWidth)
+    private static List<string> TruncateToLines(List<string> lines, int maxLines, float maxWidth, SKFont baseFont, SKFont? emojiFont, SKPaint paint)
     {
         if (lines.Count <= maxLines)
         {
@@ -187,7 +194,7 @@ internal static class CalendarEventDrawing
 
         var shown = lines.Take(maxLines).ToList();
         string last = shown[^1];
-        while (last.Length > 0 && paint.MeasureText(last + "…") > maxWidth)
+        while (last.Length > 0 && MeasureText(last + "…", baseFont, emojiFont, paint) > maxWidth)
         {
             last = last.Substring(0, last.Length - 1);
         }
@@ -196,15 +203,97 @@ internal static class CalendarEventDrawing
         return shown;
     }
 
-    private static int MaxCharsThatFit(SKPaint paint, string text, float maxWidth)
+    private static int MaxCharsThatFit(string text, float maxWidth, SKFont baseFont, SKFont? emojiFont, SKPaint paint)
     {
         int count = 0;
-        while (count < text.Length && paint.MeasureText(text.Substring(0, count + 1)) <= maxWidth)
+        while (count < text.Length && MeasureText(text.Substring(0, count + 1), baseFont, emojiFont, paint) <= maxWidth)
         {
             count++;
         }
 
         return Math.Max(1, count); // Always make progress, even for a very narrow cell.
+    }
+
+    /// <summary>
+    /// Measures text, using the emoji fallback font for any code points the default font lacks so
+    /// wrapping accounts for emoji width.
+    /// </summary>
+    private static float MeasureText(string text, SKFont baseFont, SKFont? emojiFont, SKPaint paint)
+    {
+        float width = 0f;
+        foreach ((string run, SKFont font) in SplitIntoFontRuns(text, baseFont, emojiFont))
+        {
+            width += font.MeasureText(run, paint);
+        }
+
+        return width;
+    }
+
+    /// <summary>
+    /// Draws text left-to-right from <paramref name="x"/>, switching to the emoji fallback font for
+    /// runs of glyphs the default font cannot render (so emoji actually appear).
+    /// </summary>
+    private static void DrawText(SKCanvas canvas, string text, float x, float baseline, SKFont baseFont, SKFont? emojiFont, SKPaint paint)
+    {
+        foreach ((string run, SKFont font) in SplitIntoFontRuns(text, baseFont, emojiFont))
+        {
+            canvas.DrawText(run, x, baseline, SKTextAlign.Left, font, paint);
+            x += font.MeasureText(run, paint);
+        }
+    }
+
+    /// <summary>
+    /// Groups consecutive code points of <paramref name="text"/> into runs that share a font: the
+    /// default font when it has the glyph, otherwise the emoji fallback font when available.
+    /// </summary>
+    private static IEnumerable<(string Text, SKFont Font)> SplitIntoFontRuns(string text, SKFont baseFont, SKFont? emojiFont)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield break;
+        }
+
+        var builder = new StringBuilder();
+        SKFont currentFont = baseFont;
+
+        int i = 0;
+        while (i < text.Length)
+        {
+            int codePoint;
+            int length;
+            char c = text[i];
+            if (char.IsHighSurrogate(c) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+            {
+                codePoint = char.ConvertToUtf32(c, text[i + 1]);
+                length = 2;
+            }
+            else
+            {
+                codePoint = c;
+                length = 1;
+            }
+
+            SKFont font = baseFont;
+            if (emojiFont is not null && !baseFont.ContainsGlyph(codePoint) && emojiFont.ContainsGlyph(codePoint))
+            {
+                font = emojiFont;
+            }
+
+            if (builder.Length > 0 && font != currentFont)
+            {
+                yield return (builder.ToString(), currentFont);
+                builder.Clear();
+            }
+
+            currentFont = font;
+            builder.Append(text, i, length);
+            i += length;
+        }
+
+        if (builder.Length > 0)
+        {
+            yield return (builder.ToString(), currentFont);
+        }
     }
 
     private static SKColor ParseColor(string? hex, SKColor fallback)

--- a/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
+++ b/CalendarMaker-MAUI/Services/CalendarEventDrawing.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using CalendarMaker_MAUI.Models;
 using SkiaSharp;
 
@@ -9,9 +10,18 @@ namespace CalendarMaker_MAUI.Services;
 /// </summary>
 internal static class CalendarEventDrawing
 {
+    private static readonly SKColor DefaultChipColor = new(0x4E, 0x79, 0xA7);
+    private static readonly SKColor OverflowChipColor = new(0x9E, 0x9E, 0x9E);
+
+    private const float OuterPad = 2f;
+    private const float ChipGap = 1.5f;
+    private const float TextPadX = 3f;
+    private const float TextPadY = 1.5f;
+
     /// <summary>
-    /// Draws the events occurring on <paramref name="date"/> as small colored chips stacked below the
-    /// day number inside <paramref name="cell"/>. Excess events are summarized with a "+N" chip.
+    /// Draws the events occurring on <paramref name="date"/> as colored chips stacked below the day
+    /// number inside <paramref name="cell"/>. Long titles word-wrap onto multiple lines within the
+    /// cell width; events that do not fit are summarized with a "+N more" chip.
     /// </summary>
     /// <param name="canvas">The canvas to draw on.</param>
     /// <param name="cell">The day cell rectangle.</param>
@@ -26,67 +36,175 @@ internal static class CalendarEventDrawing
             return;
         }
 
-        const float horizontalPad = 2f;
-        const float chipGap = 1.5f;
-        float chipHeight = Math.Clamp(cell.Height / 6f, 6f, 11f);
-        float fontSize = Math.Clamp(chipHeight - 3f, 5f, 8f);
+        float fontSize = Math.Clamp(cell.Height / 6f - 3f, 5f, 8f);
+        float lineHeight = fontSize + 2f;
+        float singleChipHeight = lineHeight + 2f * TextPadY;
+
+        float left = cell.Left + OuterPad;
+        float right = cell.Right - OuterPad;
+        float innerWidth = right - left - 2f * TextPadX;
 
         float top = cell.Top + dayNumberHeight;
-        float available = cell.Bottom - top - horizontalPad;
-        if (available < chipHeight)
-        {
-            return; // Cell too short to show chips.
-        }
+        float bottom = cell.Bottom - OuterPad;
+        float availableHeight = bottom - top;
 
-        int maxChips = Math.Max(1, (int)((available + chipGap) / (chipHeight + chipGap)));
-        bool needsOverflow = events.Count > maxChips;
-        int drawCount = needsOverflow ? Math.Max(1, maxChips - 1) : Math.Min(events.Count, maxChips);
+        if (innerWidth <= 1f || availableHeight < singleChipHeight)
+        {
+            return; // Cell too small to show any chips.
+        }
 
         using var chipPaint = new SKPaint { Style = SKPaintStyle.Fill, IsAntialias = true };
         using var textPaint = new SKPaint { TextSize = fontSize, IsAntialias = true };
 
-        float left = cell.Left + horizontalPad;
-        float right = cell.Right - horizontalPad;
-        float y = top;
-
-        for (int i = 0; i < drawCount; i++)
+        // Lay out as many event chips as fit, each wrapped to the cell width.
+        var chips = new List<(List<string> Lines, SKColor Color)>();
+        float usedHeight = 0f;
+        int placed = 0;
+        for (; placed < events.Count; placed++)
         {
-            var ev = events[i];
-            var chipRect = new SKRect(left, y, right, y + chipHeight);
-            SKColor color = ParseColor(ev.ColorHex, new SKColor(0x4E, 0x79, 0xA7));
-            chipPaint.Color = color;
-            float radius = chipHeight / 3f;
-            canvas.DrawRoundRect(chipRect, radius, radius, chipPaint);
-
-            string label = ev.Title.Trim();
-            if (!string.IsNullOrEmpty(label))
+            var lines = WrapText(textPaint, events[placed].Title.Trim(), innerWidth);
+            if (lines.Count == 0)
             {
-                textPaint.Color = ContrastingTextColor(color);
-                DrawClippedText(canvas, textPaint, label, chipRect, fontSize);
+                lines.Add(string.Empty);
             }
 
-            y += chipHeight + chipGap;
+            float chipHeight = lines.Count * lineHeight + 2f * TextPadY;
+            float needed = chipHeight + (chips.Count > 0 ? ChipGap : 0f);
+            if (usedHeight + needed > availableHeight)
+            {
+                break;
+            }
+
+            chips.Add((lines, ParseColor(events[placed].ColorHex, DefaultChipColor)));
+            usedHeight += needed;
         }
 
-        if (needsOverflow)
+        // If even the first event is taller than the cell, show it truncated rather than nothing.
+        if (chips.Count == 0)
         {
-            int remaining = events.Count - drawCount;
+            int maxLines = Math.Max(1, (int)((availableHeight - 2f * TextPadY) / lineHeight));
+            var lines = TruncateToLines(textPaint, WrapText(textPaint, events[0].Title.Trim(), innerWidth), maxLines, innerWidth);
+            chips.Add((lines, ParseColor(events[0].ColorHex, DefaultChipColor)));
+            usedHeight = lines.Count * lineHeight + 2f * TextPadY;
+            placed = 1;
+        }
+
+        int leftover = events.Count - placed;
+
+        // Reserve room for a "+N more" chip, dropping trailing events if necessary.
+        if (leftover > 0)
+        {
+            float overflowNeeded = singleChipHeight + ChipGap;
+            while (chips.Count > 1 && usedHeight + overflowNeeded > availableHeight)
+            {
+                var dropped = chips[^1];
+                usedHeight -= dropped.Lines.Count * lineHeight + 2f * TextPadY + ChipGap;
+                chips.RemoveAt(chips.Count - 1);
+                leftover++;
+            }
+        }
+
+        // Render the chips.
+        float y = top;
+        foreach (var (lines, color) in chips)
+        {
+            float chipHeight = lines.Count * lineHeight + 2f * TextPadY;
             var chipRect = new SKRect(left, y, right, y + chipHeight);
-            chipPaint.Color = new SKColor(0x9E, 0x9E, 0x9E);
-            float radius = chipHeight / 3f;
-            canvas.DrawRoundRect(chipRect, radius, radius, chipPaint);
-            textPaint.Color = SKColors.White;
-            DrawClippedText(canvas, textPaint, $"+{remaining}", chipRect, fontSize);
+            DrawChip(canvas, chipPaint, textPaint, chipRect, lines, color, lineHeight, fontSize);
+            y = chipRect.Bottom + ChipGap;
+        }
+
+        // Render the overflow indicator if any events did not fit.
+        if (leftover > 0 && y + singleChipHeight <= bottom + 0.5f)
+        {
+            var chipRect = new SKRect(left, y, right, y + singleChipHeight);
+            DrawChip(canvas, chipPaint, textPaint, chipRect, new List<string> { $"+{leftover} more" }, OverflowChipColor, lineHeight, fontSize);
         }
     }
 
-    private static void DrawClippedText(SKCanvas canvas, SKPaint textPaint, string text, SKRect chipRect, float fontSize)
+    private static void DrawChip(SKCanvas canvas, SKPaint chipPaint, SKPaint textPaint, SKRect chipRect, List<string> lines, SKColor color, float lineHeight, float fontSize)
     {
+        chipPaint.Color = color;
+        float radius = Math.Min(4f, chipRect.Height / 3f);
+        canvas.DrawRoundRect(chipRect, radius, radius, chipPaint);
+
+        textPaint.Color = ContrastingTextColor(color);
         canvas.Save();
         canvas.ClipRect(chipRect);
-        float baseline = chipRect.MidY + fontSize / 2.8f;
-        canvas.DrawText(text, chipRect.Left + 2f, baseline, textPaint);
+        float baseline = chipRect.Top + TextPadY + fontSize;
+        foreach (string line in lines)
+        {
+            canvas.DrawText(line, chipRect.Left + TextPadX, baseline, textPaint);
+            baseline += lineHeight;
+        }
         canvas.Restore();
+    }
+
+    /// <summary>
+    /// Splits <paramref name="text"/> into lines that each fit within <paramref name="maxWidth"/>,
+    /// breaking on spaces and hard-breaking any single word that is wider than the line.
+    /// </summary>
+    private static List<string> WrapText(SKPaint paint, string text, float maxWidth)
+    {
+        var lines = new List<string>();
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return lines;
+        }
+
+        foreach (string word in text.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (lines.Count > 0)
+            {
+                string candidate = lines[^1] + " " + word;
+                if (paint.MeasureText(candidate) <= maxWidth)
+                {
+                    lines[^1] = candidate;
+                    continue;
+                }
+            }
+
+            string remaining = word;
+            while (paint.MeasureText(remaining) > maxWidth && remaining.Length > 1)
+            {
+                int fit = MaxCharsThatFit(paint, remaining, maxWidth);
+                lines.Add(remaining.Substring(0, fit));
+                remaining = remaining.Substring(fit);
+            }
+
+            lines.Add(remaining);
+        }
+
+        return lines;
+    }
+
+    private static List<string> TruncateToLines(SKPaint paint, List<string> lines, int maxLines, float maxWidth)
+    {
+        if (lines.Count <= maxLines)
+        {
+            return lines;
+        }
+
+        var shown = lines.Take(maxLines).ToList();
+        string last = shown[^1];
+        while (last.Length > 0 && paint.MeasureText(last + "…") > maxWidth)
+        {
+            last = last.Substring(0, last.Length - 1);
+        }
+
+        shown[^1] = last + "…";
+        return shown;
+    }
+
+    private static int MaxCharsThatFit(SKPaint paint, string text, float maxWidth)
+    {
+        int count = 0;
+        while (count < text.Length && paint.MeasureText(text.Substring(0, count + 1)) <= maxWidth)
+        {
+            count++;
+        }
+
+        return Math.Max(1, count); // Always make progress, even for a very narrow cell.
     }
 
     private static SKColor ParseColor(string? hex, SKColor fallback)

--- a/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
+++ b/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
@@ -90,6 +90,8 @@ public class CalendarRendererDayCellsTests
     [InlineData("A really long multi word event title that must wrap onto several lines")]
     [InlineData("Supercalifragilisticexpialidociousunbreakablesingleword")] // no spaces -> hard break
     [InlineData("")] // empty title
+    [InlineData("Mom's Birthday 🎂 party 🎉")] // emoji in title (font fallback path)
+    [InlineData("🏈🎂🎉⭐❤️🎄")] // emoji-only title
     public void RenderCalendarGrid_WithLongOrAwkwardTitle_WrapsWithoutThrowing(string title)
     {
         var renderer = CreateRenderer();

--- a/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
+++ b/CalendarMaker.Tests/Services/CalendarRendererDayCellsTests.cs
@@ -86,6 +86,60 @@ public class CalendarRendererDayCellsTests
         }
     }
 
+    [Theory]
+    [InlineData("A really long multi word event title that must wrap onto several lines")]
+    [InlineData("Supercalifragilisticexpialidociousunbreakablesingleword")] // no spaces -> hard break
+    [InlineData("")] // empty title
+    public void RenderCalendarGrid_WithLongOrAwkwardTitle_WrapsWithoutThrowing(string title)
+    {
+        var renderer = CreateRenderer();
+        var project = new CalendarProject { FirstDayOfWeek = DayOfWeek.Sunday };
+        project.Events.Add(new CalendarEvent
+        {
+            Title = title,
+            ColorHex = "#4E79A7",
+            Recurrence = EventRecurrence.Annually,
+            Month = 1,
+            Day = 15
+        });
+        var (bmp, canvas) = CreateCanvas();
+
+        using (bmp)
+        using (canvas)
+        {
+            // Use a narrow grid so day cells are small and wrapping/hard-breaking is exercised.
+            var act = () => renderer.RenderCalendarGrid(canvas, new SKRect(0, 0, 240, 260), project, 2025, 1);
+            act.Should().NotThrow();
+        }
+    }
+
+    [Fact]
+    public void RenderCalendarGrid_ManyEventsOnOneDay_DoesNotThrow()
+    {
+        var renderer = CreateRenderer();
+        var project = new CalendarProject { FirstDayOfWeek = DayOfWeek.Sunday };
+        for (int i = 0; i < 10; i++)
+        {
+            project.Events.Add(new CalendarEvent
+            {
+                Title = $"Event number {i} with a fairly long title",
+                ColorHex = "#E15759",
+                Recurrence = EventRecurrence.None,
+                Year = 2025,
+                Month = 1,
+                Day = 15
+            });
+        }
+        var (bmp, canvas) = CreateCanvas();
+
+        using (bmp)
+        using (canvas)
+        {
+            var act = () => renderer.RenderCalendarGrid(canvas, new SKRect(0, 0, 600, 500), project, 2025, 1);
+            act.Should().NotThrow();
+        }
+    }
+
     [Fact]
     public void RenderCalendarGrid_NullDayCellBounds_IsAllowed()
     {


### PR DESCRIPTION
Improves how event titles are drawn in day cells (preview + exported PDF, via the shared `CalendarEventDrawing` routine).

## 1. Word-wrap long titles
Long titles previously rendered on a single line and were clipped at the cell edge. Now they **word-wrap** onto multiple lines:
- Each event chip grows vertically to fit its wrapped title.
- A single word wider than the cell is hard-broken across lines.
- If one event is taller than the whole cell, it's truncated with an ellipsis (…) rather than hidden.
- Events that still don't fit are summarized with a **"+N more"** chip.

## 2. Render emoji in titles
Emoji typed into a title (the intended way to add one, since the separate emoji field was removed) didn't appear in the preview or PDF: SkiaSharp's `DrawText` uses a single typeface and doesn't fall back to an emoji font. Text is now drawn — and measured, so wrapping stays correct — **run-by-run**, using an emoji-capable fallback typeface (`SKFontManager.MatchCharacter`, e.g. Segoe UI Emoji on Windows) for code points the default font can't render. This also moves the text drawing off the obsolete `SKPaint` text APIs onto `SKFont`.

## Testing
- `dotnet build`: 0 errors.
- `dotnet test`: **139/139 passing**, including render tests for long multi-word titles, an unbreakable single word, an empty title, emoji-containing and emoji-only titles, and many events on one day.
- Visually verified by rendering full months to PNG: long titles wrap within their cells, and 🎂/🎉/🏈 render in color inside the chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)